### PR TITLE
Fix backface culling wind order in cube samples.

### DIFF
--- a/fractal_cube.html
+++ b/fractal_cube.html
@@ -211,7 +211,7 @@ async function init() {
         },
 
         rasterizationState: {
-            frontFace: 'cw',
+            frontFace: 'ccw',
             cullMode: 'back',
         },
 

--- a/rotating_cube.html
+++ b/rotating_cube.html
@@ -181,7 +181,7 @@ async function init() {
         },
 
         rasterizationState: {
-            frontFace: 'cw',
+            frontFace: 'ccw',
             cullMode: 'back',
         },
 

--- a/textured_cube.html
+++ b/textured_cube.html
@@ -269,7 +269,7 @@ async function init() {
         },
 
         rasterizationState: {
-            frontFace: 'cw',
+            frontFace: 'ccw',
             cullMode: 'back',
         },
 


### PR DESCRIPTION
This updates the wind order so the samples don't render inside-out.