### PR TITLE
Flip vertex y-axis

### DIFF
--- a/fractal_cube.html
+++ b/fractal_cube.html
@@ -112,7 +112,7 @@ void main() {
 
             const aspect = Math.abs(canvas.width / canvas.height);
             let projectionMatrix = mat4.create();
-            mat4.perspective(projectionMatrix, (2 * Math.PI) / 5, aspect, 1, 100.0);
+            mat4.perspective(projectionMatrix, (2 * Math.PI) / 5, -aspect, 1, 100.0);
 
             const context = canvas.getContext('gpupresent');
 

--- a/rotating_cube.html
+++ b/rotating_cube.html
@@ -99,7 +99,7 @@ void main() {
 
             const aspect = Math.abs(canvas.width / canvas.height);
             let projectionMatrix = mat4.create();
-            mat4.perspective(projectionMatrix, (2 * Math.PI) / 5, aspect, 1, 100.0);
+            mat4.perspective(projectionMatrix, (2 * Math.PI) / 5, -aspect, 1, 100.0);
 
             const context = canvas.getContext('gpupresent');
 

--- a/textured_cube.html
+++ b/textured_cube.html
@@ -102,7 +102,7 @@ void main() {
 
             const aspect = Math.abs(canvas.width / canvas.height);
             let projectionMatrix = mat4.create();
-            mat4.perspective(projectionMatrix, (2 * Math.PI) / 5, aspect, 1, 100.0);
+            mat4.perspective(projectionMatrix, (2 * Math.PI) / 5, -aspect, 1, 100.0);
 
             const context = canvas.getContext('gpupresent');
 


### PR DESCRIPTION
Fixes examples to match upstream Chrome changes that fix Chrome to match
the WebGPU spec.

https://dawn.googlesource.com/dawn/+/d2631f86e727c78e3f60ff96a2921d429e321bd4
https://chromium.googlesource.com/chromium/src/+/ce7e12009c5655065cafc36763f1ed5bf6cf6de7