### PR TITLE
Improve shader editor save functionality

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -108,16 +108,23 @@
         overflow: visible !important;
       }
 
-      .shaderEditor > .CodeMirror::before {
-        content: "Edit me! (Ctrl+S to save)";
-        width: 100%;
+      .shaderEditor::before {
+        content: "Edit me! (Save to update)";
         position: relative;
         display: block;
         font-weight: bold;
         text-align: right;
-        box-sizing: border-box;
-        padding-top: 5px;
-        padding-right: 10px;
+        margin-bottom: -0.5em;
+        margin-right: 5px;
+      }
+
+      .updateShaderBtn {
+        position: relative;
+        left: 100%;
+        transform: translateX(-108%);
+        margin-right: 10px;
+        margin-top: 5px;
+        cursor: pointer;
       }
     </style>
   </head>

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,15 @@ function removeClassName(el: HTMLElement, className: string) {
     el.className = (el.className || '').replace(className, '');
 }
 
+interface ShaderEditor extends CodeMirror.Editor {
+  updatedSource: (source: any) => void,
+};
+
+// @ts-ignore
+CodeMirror.commands.save = function(editor: ShaderEditor) {
+    editor.updatedSource(editor.getValue());
+}
+
 setShaderRegisteredCallback(async (source, updatedSource) => {
     const el = document.createElement('div');
     shaderEditor.appendChild(el);
@@ -26,13 +35,16 @@ setShaderRegisteredCallback(async (source, updatedSource) => {
         lineNumbers: true,
         lineWrapping: true,
         theme: 'monokai',
-        extraKeys: {
-            'Ctrl-S': function() {
-                updatedSource(editor.getValue());
-            }
-        }
     };
-    const editor: CodeMirror.Editor = CodeMirror(el, configuration);
+    const editor = CodeMirror(el, configuration) as ShaderEditor;
+    editor.updatedSource = updatedSource;
+
+    const codeMirrorContainer = el.firstElementChild;
+    const updateButton = document.createElement('button');
+    updateButton.className = "updateShaderBtn";
+    updateButton.innerHTML = "Update shader";
+    updateButton.onclick = () => updatedSource(editor.getValue());
+    codeMirrorContainer.prepend(updateButton);
 });
 
 let currentCanvas = undefined;


### PR DESCRIPTION
In #55, it was reported that saving the page as HTML doesn't work
as expected. This commit does not directly solve the problem, but
it does make saving while the shader editor has focus more
convenient. It overrides CodeMirror's default "save" command
instead of always using "Ctrl+S". This captures the event,
prevents the default page save action, and maps to the correct
key combination if the user is on Windows/Linux/Mac. This commit
also adds a button to make it super clear you can press the button
to live update a shader.