### PR TITLE
Update WGSL syntax for the latest Canary

### DIFF
--- a/src/examples/animometer.ts
+++ b/src/examples/animometer.ts
@@ -88,7 +88,6 @@ export async function init(canvas: HTMLCanvasElement, useWGSL: boolean) {
     },
     primitiveTopology: "triangle-list",
     vertexState: {
-      indexFormat: "uint32",
       vertexBuffers: [
         {
           // vertex buffer

--- a/src/examples/animometer.ts
+++ b/src/examples/animometer.ts
@@ -383,30 +383,29 @@ export const glslShaders = {
 
 export const wgslShaders = {
   vertex: `
-import "GLSL.std.450" as std;
-
 type Time = [[block]] struct {
-  [[offset 0]] value : f32;
+  [[offset(0)]] value : f32;
 };
 
 type Uniforms = [[block]] struct {
-  [[offset 0]] scale : f32;
-  [[offset 4]] offsetX : f32;
-  [[offset 8]] offsetY : f32;
-  [[offset 12]] scalar : f32;
-  [[offset 16]] scalarOffset : f32;
+  [[offset(0)]] scale : f32;
+  [[offset(4)]] offsetX : f32;
+  [[offset(8)]] offsetY : f32;
+  [[offset(12)]] scalar : f32;
+  [[offset(16)]] scalarOffset : f32;
 };
 
-[[binding 0, set 0]] var<uniform> time : Time;
-[[binding 0, set 1]] var<uniform> uniforms : Uniforms;
+[[binding(0), set(0)]] var<uniform> time : Time;
+[[binding(0), set(1)]] var<uniform> uniforms : Uniforms;
 
-[[location 0]] var<in> position : vec4<f32>;
-[[location 1]] var<in> color : vec4<f32>;
+[[location(0)]] var<in> position : vec4<f32>;
+[[location(1)]] var<in> color : vec4<f32>;
 
-[[builtin position]] var<out> Position : vec4<f32>;
-[[location 0]] var<out> v_color : vec4<f32>;
+[[builtin(position)]] var<out> Position : vec4<f32>;
+[[location(0)]] var<out> v_color : vec4<f32>;
 
-fn vtx_main() -> void {
+[[stage(vertex)]]
+fn main() -> void {
     var fade : f32 = (uniforms.scalarOffset + time.value * uniforms.scalar / 10.0) % 1.0;
     if (fade < 0.5) {
         fade = fade * 2.0;
@@ -416,25 +415,24 @@ fn vtx_main() -> void {
     var xpos : f32 = position.x * uniforms.scale;
     var ypos : f32 = position.y * uniforms.scale;
     var angle : f32 = 3.14159 * 2.0 * fade;
-    var xrot : f32 = xpos * std::cos(angle) - ypos * std::sin(angle);
-    var yrot : f32 = xpos * std::sin(angle) + ypos * std::cos(angle);
+    var xrot : f32 = xpos * cos(angle) - ypos * sin(angle);
+    var yrot : f32 = xpos * sin(angle) + ypos * cos(angle);
     xpos = xrot + uniforms.offsetX;
     ypos = yrot + uniforms.offsetY;
     v_color = vec4<f32>(fade, 1.0 - fade, 0.0, 1.0) + color;
     Position = vec4<f32>(xpos, ypos, 0.0, 1.0);
     return;
 }
-entry_point vertex as "main" = vtx_main;
 `,
 
   fragment: `
-[[location 0]] var<in> v_color : vec4<f32>;
-[[location 0]] var<out> outColor : vec4<f32>;
+[[location(0)]] var<in> v_color : vec4<f32>;
+[[location(0)]] var<out> outColor : vec4<f32>;
 
-fn frag_main() -> void {
+[[stage(fragment)]]
+fn main() -> void {
   outColor = v_color;
   return;
 }
-entry_point fragment as "main" = frag_main;
 `,
 };

--- a/src/examples/computeBoids.ts
+++ b/src/examples/computeBoids.ts
@@ -336,57 +336,57 @@ void main() {
 
 export const wgslShaders = {
   vertex: `
-import "GLSL.std.450" as std;
+[[location(0)]] var<in> a_particlePos : vec2<f32>;
+[[location(1)]] var<in> a_particleVel : vec2<f32>;
+[[location(2)]] var<in> a_pos : vec2<f32>;
+[[builtin(position)]] var<out> Position : vec4<f32>;
 
-[[location 0]] var<in> a_particlePos : vec2<f32>;
-[[location 1]] var<in> a_particleVel : vec2<f32>;
-[[location 2]] var<in> a_pos : vec2<f32>;
-[[builtin position]] var<out> Position : vec4<f32>;
-fn vtx_main() -> void {
-  var angle : f32 = -std::atan2(a_particleVel.x, a_particleVel.y);
+[[stage(vertex)]]
+fn main() -> void {
+  var angle : f32 = -atan2(a_particleVel.x, a_particleVel.y);
   var pos : vec2<f32> = vec2<f32>(
-      (a_pos.x * std::cos(angle)) - (a_pos.y * std::sin(angle)),
-      (a_pos.x * std::sin(angle)) + (a_pos.y * std::cos(angle)));
+      (a_pos.x * cos(angle)) - (a_pos.y * sin(angle)),
+      (a_pos.x * sin(angle)) + (a_pos.y * cos(angle)));
   Position = vec4<f32>(pos + a_particlePos, 0.0, 1.0);
   return;
 }
-entry_point vertex as "main" = vtx_main;
 `,
 
   fragment: `
-[[location 0]] var<out> fragColor : vec4<f32>;
-fn frag_main() -> void {
+[[location(0)]] var<out> fragColor : vec4<f32>;
+
+[[stage(fragment)]]
+fn main() -> void {
   fragColor = vec4<f32>(1.0, 1.0, 1.0, 1.0);
   return;
 }
-entry_point fragment as "main" = frag_main;
 `,
 
   compute: (numParticles: number) => `
-import "GLSL.std.450" as std;
-
 type Particle = [[block]] struct {
-  [[offset 0]] pos : vec2<f32>;
-  [[offset 8]] vel : vec2<f32>;
+  [[offset(0)]] pos : vec2<f32>;
+  [[offset(8)]] vel : vec2<f32>;
 };
 type SimParams = [[block]] struct {
-  [[offset 0]] deltaT : f32;
-  [[offset 4]] rule1Distance : f32;
-  [[offset 8]] rule2Distance : f32;
-  [[offset 12]] rule3Distance : f32;
-  [[offset 16]] rule1Scale : f32;
-  [[offset 20]] rule2Scale : f32;
-  [[offset 24]] rule3Scale : f32;
+  [[offset(0)]] deltaT : f32;
+  [[offset(4)]] rule1Distance : f32;
+  [[offset(8)]] rule2Distance : f32;
+  [[offset(12)]] rule3Distance : f32;
+  [[offset(16)]] rule1Scale : f32;
+  [[offset(20)]] rule2Scale : f32;
+  [[offset(24)]] rule3Scale : f32;
 };
 type Particles = [[block]] struct {
-  [[offset 0]] particles : [[stride 16]] array<Particle, ${numParticles}>;
+  [[offset(0)]] particles : [[stride(16)]] array<Particle, ${numParticles}>;
 };
-[[binding 0, set 0]] var<uniform> params : SimParams;
-[[binding 1, set 0]] var<storage_buffer> particlesA : Particles;
-[[binding 2, set 0]] var<storage_buffer> particlesB : Particles;
-[[builtin global_invocation_id]] var<in> GlobalInvocationID : vec3<u32>;
+[[binding(0), set(0)]] var<uniform> params : SimParams;
+[[binding(1), set(0)]] var<storage_buffer> particlesA : Particles;
+[[binding(2), set(0)]] var<storage_buffer> particlesB : Particles;
+[[builtin(global_invocation_id)]] var<in> GlobalInvocationID : vec3<u32>;
+
 # https://github.com/austinEng/Project6-Vulkan-Flocking/blob/master/data/shaders/computeparticles/particle.comp
-fn compute_main() -> void {
+[[stage(compute)]]
+fn main() -> void {
   var index : u32 = GlobalInvocationID.x;
   if (index >= ${numParticles}) {
     return;
@@ -408,29 +408,30 @@ fn compute_main() -> void {
 
     pos = particlesA.particles[i].pos.xy;
     vel = particlesA.particles[i].vel.xy;
-    if (std::distance(pos, vPos) < params.rule1Distance) {
+    if (distance(pos, vPos) < params.rule1Distance) {
       cMass = cMass + pos;
       cMassCount = cMassCount + 1;
     }
-    if (std::distance(pos, vPos) < params.rule2Distance) {
+    if (distance(pos, vPos) < params.rule2Distance) {
       colVel = colVel - (pos - vPos);
     }
-    if (std::distance(pos, vPos) < params.rule3Distance) {
+    if (distance(pos, vPos) < params.rule3Distance) {
       cVel = cVel + vel;
       cVelCount = cVelCount + 1;
     }
   }
   if (cMassCount > 0) {
     cMass =
-      (cMass / vec2<f32>(cast<f32>(cMassCount), cast<f32>(cMassCount))) - vPos;
+      (cMass / vec2<f32>(f32(cMassCount), f32(cMassCount))) - vPos;
   }
   if (cVelCount > 0) {
-    cVel = cVel / vec2<f32>(cast<f32>(cVelCount), cast<f32>(cVelCount));
+    cVel = cVel / vec2<f32>(f32(cVelCount), f32(cVelCount));
   }
   vVel = vVel + (cMass * params.rule1Scale) + (colVel * params.rule2Scale) +
       (cVel * params.rule3Scale);
+
   # clamp velocity for a more pleasing simulation
-  vVel = std::normalize(vVel) * std::fclamp(std::length(vVel), 0.0, 0.1);
+  vVel = normalize(vVel) * clamp(length(vVel), 0.0, 0.1);
   # kinematic update
   vPos = vPos + (vVel * params.deltaT);
   # Wrap around boundary
@@ -451,6 +452,5 @@ fn compute_main() -> void {
   particlesB.particles[index].vel = vVel;
   return;
 }
-entry_point compute as "main" = compute_main;
 `,
 };

--- a/src/examples/helloTriangle.ts
+++ b/src/examples/helloTriangle.ts
@@ -99,21 +99,22 @@ var<private> pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
     vec2<f32>(-0.5, -0.5),
     vec2<f32>(0.5, -0.5));
 
-[[builtin position]] var<out> Position : vec4<f32>;
-[[builtin vertex_idx]] var<in> VertexIndex : i32;
+[[builtin(position)]] var<out> Position : vec4<f32>;
+[[builtin(vertex_idx)]] var<in> VertexIndex : i32;
 
-fn vtx_main() -> void {
+[[stage(vertex)]]
+fn main() -> void {
   Position = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
   return;
 }
-entry_point vertex as "main" = vtx_main;
 `,
   fragment: `
-[[location 0]] var<out> outColor : vec4<f32>;
-fn frag_main() -> void {
+[[location(0)]] var<out> outColor : vec4<f32>;
+
+[[stage(fragment)]]
+fn main() -> void {
   outColor = vec4<f32>(1.0, 0.0, 0.0, 1.0);
   return;
 }
-entry_point fragment as "main" = frag_main;
 `,
 };

--- a/src/examples/helloTriangleMSAA.ts
+++ b/src/examples/helloTriangleMSAA.ts
@@ -115,21 +115,22 @@ var<private> pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
     vec2<f32>(-0.5, -0.5),
     vec2<f32>(0.5, -0.5));
 
-[[builtin position]] var<out> Position : vec4<f32>;
-[[builtin vertex_idx]] var<in> VertexIndex : i32;
+[[builtin(position)]] var<out> Position : vec4<f32>;
+[[builtin(vertex_idx)]] var<in> VertexIndex : i32;
 
-fn vtx_main() -> void {
+[[stage(vertex)]]
+fn main() -> void {
   Position = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
   return;
 }
-entry_point vertex as "main" = vtx_main;
 `,
   fragment: `
-[[location 0]] var<out> outColor : vec4<f32>;
-fn frag_main() -> void {
+[[location(0)]] var<out> outColor : vec4<f32>;
+
+[[stage(fragment)]]
+fn main() -> void {
   outColor = vec4<f32>(1.0, 0.0, 0.0, 1.0);
   return;
 }
-entry_point fragment as "main" = frag_main;
 `,
 };

--- a/src/examples/instancedCube.ts
+++ b/src/examples/instancedCube.ts
@@ -240,33 +240,33 @@ void main() {
 export const wgslShaders = {
   vertex: `
 type Uniforms = [[block]] struct {
-  [[offset 0]] modelViewProjectionMatrix : [[stride 64]] array<mat4x4<f32>, 16>;
+  [[offset(0)]] modelViewProjectionMatrix : [[stride(64)]] array<mat4x4<f32>, 16>;
 };
 
-[[binding 0, set 0]] var<uniform> uniforms : Uniforms;
+[[binding(0), set(0)]] var<uniform> uniforms : Uniforms;
 
-[[builtin instance_idx]] var<in> instanceIdx : i32;
-[[location 0]] var<in> position : vec4<f32>;
-[[location 1]] var<in> color : vec4<f32>;
+[[builtin(instance_idx)]] var<in> instanceIdx : i32;
+[[location(0)]] var<in> position : vec4<f32>;
+[[location(1)]] var<in> color : vec4<f32>;
 
-[[builtin position]] var<out> Position : vec4<f32>;
-[[location 0]] var<out> fragColor : vec4<f32>;
+[[builtin(position)]] var<out> Position : vec4<f32>;
+[[location(0)]] var<out> fragColor : vec4<f32>;
 
-fn vtx_main() -> void {
+[[stage(vertex)]]
+fn main() -> void {
   Position = uniforms.modelViewProjectionMatrix[instanceIdx] * position;
   fragColor = color;
   return;
 }
-entry_point vertex as "main" = vtx_main;
 `,
   fragment: `
-[[location 0]] var<in> fragColor : vec4<f32>;
-[[location 0]] var<out> outColor : vec4<f32>;
+[[location(0)]] var<in> fragColor : vec4<f32>;
+[[location(0)]] var<out> outColor : vec4<f32>;
 
-fn frag_main() -> void {
+[[stage(fragment)]]
+fn main() -> void {
   outColor = fragColor;
   return;
 }
-entry_point fragment as "main" = frag_main;
 `,
 };

--- a/src/examples/rotatingCube.ts
+++ b/src/examples/rotatingCube.ts
@@ -212,32 +212,32 @@ void main() {
 export const wgslShaders = {
   vertex: `
 type Uniforms = [[block]] struct {
-  [[offset 0]] modelViewProjectionMatrix : mat4x4<f32>;
+  [[offset(0)]] modelViewProjectionMatrix : mat4x4<f32>;
 };
 
-[[binding 0, set 0]] var<uniform> uniforms : Uniforms;
+[[binding(0), set(0)]] var<uniform> uniforms : Uniforms;
 
-[[location 0]] var<in> position : vec4<f32>;
-[[location 1]] var<in> color : vec4<f32>;
+[[location(0)]] var<in> position : vec4<f32>;
+[[location(1)]] var<in> color : vec4<f32>;
 
-[[builtin position]] var<out> Position : vec4<f32>;
-[[location 0]] var<out> fragColor : vec4<f32>;
+[[builtin(position)]] var<out> Position : vec4<f32>;
+[[location(0)]] var<out> fragColor : vec4<f32>;
 
-fn vtx_main() -> void {
+[[stage(vertex)]]
+fn main() -> void {
   Position = uniforms.modelViewProjectionMatrix * position;
   fragColor = color;
   return;
 }
-entry_point vertex as "main" = vtx_main;
 `,
   fragment: `
-[[location 0]] var<in> fragColor : vec4<f32>;
-[[location 0]] var<out> outColor : vec4<f32>;
+[[location(0)]] var<in> fragColor : vec4<f32>;
+[[location(0)]] var<out> outColor : vec4<f32>;
 
-fn frag_main() -> void {
+[[stage(fragment)]]
+fn main() -> void {
   outColor = fragColor;
   return;
 }
-entry_point fragment as "main" = frag_main;
 `,
 };

--- a/src/examples/texturedCube.ts
+++ b/src/examples/texturedCube.ts
@@ -203,3 +203,41 @@ void main() {
 }
 `,
 };
+
+export const wgslShaders = {
+  vertex: `
+type Uniforms = [[block]] struct {
+  [[offset 0]] modelViewProjectionMatrix : mat4x4<f32>;
+};
+[[binding 0, set 0]] var<uniform> uniforms : Uniforms;
+
+[[location 0]] var<in> position : vec4<f32>;
+[[location 1]] var<in> uv : vec2<f32>;
+
+[[builtin position]] var<out> Position : vec4<f32>;
+[[location 0]] var<out> fragUV : vec2<f32>;
+[[location 1]] var<out> fragPosition: vec4<f32>;
+
+fn vtx_main() -> void {
+  fragPosition = 0.5 * (position + vec4(1.0));
+  Position = uniforms.modelViewProjectionMatrix * position;
+  fragUV = uv;
+  return;
+}
+entry_point vertex as "main" = vtx_main;
+`,
+  fragment: `
+[[binding = 1, set = 0]] var<uniform> mySampler: sampler;
+[[binding = 2, set = 0]] var<uniform> myTexture: texture_sampled_2d<f32>;
+
+[[location = 0]] var<in> fragUV: vec2<f32>;
+[[location = 1]] var<in> fragPosition: vec4<f32>;
+[[location 0]] var<out> outColor : vec4<f32>;
+
+fn frag_main() -> void {
+  outColor =  textureSample(myTexture, mySampler, fragUV) * fragPosition;
+  return;
+}
+entry_point fragment as "main" = frag_main;
+`,
+};

--- a/src/examples/texturedCube.ts
+++ b/src/examples/texturedCube.ts
@@ -238,37 +238,37 @@ void main() {
 export const wgslShaders = {
   vertex: `
 type Uniforms = [[block]] struct {
-  [[offset 0]] modelViewProjectionMatrix : mat4x4<f32>;
+  [[offset(0)]] modelViewProjectionMatrix : mat4x4<f32>;
 };
-[[binding 0, set 0]] var<uniform> uniforms : Uniforms;
+[[binding(0), set(0)]] var<uniform> uniforms : Uniforms;
 
-[[location 0]] var<in> position : vec4<f32>;
-[[location 1]] var<in> uv : vec2<f32>;
+[[location(0)]] var<in> position : vec4<f32>;
+[[location(1)]] var<in> uv : vec2<f32>;
 
-[[builtin position]] var<out> Position : vec4<f32>;
-[[location 0]] var<out> fragUV : vec2<f32>;
-[[location 1]] var<out> fragPosition: vec4<f32>;
+[[builtin(position)]] var<out> Position : vec4<f32>;
+[[location(0)]] var<out> fragUV : vec2<f32>;
+[[location(1)]] var<out> fragPosition: vec4<f32>;
 
-fn vtx_main() -> void {
-  fragPosition = 0.5 * (position + vec4<f32>(1.0));
+[[stage(vertex)]]
+fn main() -> void {
+  fragPosition = 0.5 * (position + vec4<f32>(1.0, 1.0, 1.0, 1.0));
   Position = uniforms.modelViewProjectionMatrix * position;
   fragUV = uv;
   return;
 }
-entry_point vertex as "main" = vtx_main;
 `,
   fragment: `
-[[binding 0, set 0]] var<uniform> mySampler: sampler;
-[[binding 0, set 0]] var<uniform> myTexture: texture_sampled_2d<f32>;
+[[binding(1), set(0)]] var<uniform> mySampler: sampler;
+[[binding(2), set(0)]] var<uniform> myTexture: texture_sampled_2d<f32>;
 
-[[location 0]] var<in> fragUV: vec2<f32>;
-[[location 1]] var<in> fragPosition: vec4<f32>;
-[[location 0]] var<out> outColor : vec4<f32>;
+[[location(0)]] var<in> fragUV: vec2<f32>;
+[[location(1)]] var<in> fragPosition: vec4<f32>;
+[[location(0)]] var<out> outColor : vec4<f32>;
 
-fn frag_main() -> void {
+[[stage(fragment)]]
+fn main() -> void {
   outColor =  textureSample(myTexture, mySampler, fragUV) * fragPosition;
   return;
 }
-entry_point fragment as "main" = frag_main;
 `,
 };

--- a/src/examples/texturedCube.ts
+++ b/src/examples/texturedCube.ts
@@ -30,7 +30,30 @@ export async function init(canvas: HTMLCanvasElement, useWGSL: boolean) {
   new Float32Array(verticesBuffer.getMappedRange()).set(cubeVertexArray);
   verticesBuffer.unmap();
 
+  const bindGroupLayout = device.createBindGroupLayout({
+    entries: [{
+      // Transform
+      binding: 0,
+      visibility: GPUShaderStage.VERTEX,
+      type: "uniform-buffer"
+    }, {
+      // Sampler
+      binding: 1,
+      visibility: GPUShaderStage.FRAGMENT,
+      type: "sampler"
+    }, {
+      // Texture view
+      binding: 2,
+      visibility: GPUShaderStage.FRAGMENT,
+      type: "sampled-texture"
+    }]
+  });
+
+  const pipelineLayout = device.createPipelineLayout({ bindGroupLayouts: [bindGroupLayout] });
+
   const pipeline = device.createRenderPipeline({
+    layout: pipelineLayout,
+
     vertexStage: {
       module: useWGSL
         ? device.createShaderModule({

--- a/src/examples/twoCubes.ts
+++ b/src/examples/twoCubes.ts
@@ -244,32 +244,32 @@ void main() {
 export const wgslShaders = {
   vertex: `
 type Uniforms = [[block]] struct {
-  [[offset 0]] modelViewProjectionMatrix : mat4x4<f32>;
+  [[offset(0)]] modelViewProjectionMatrix : mat4x4<f32>;
 };
 
-[[binding 0, set 0]] var<uniform> uniforms : Uniforms;
+[[binding(0), set(0)]] var<uniform> uniforms : Uniforms;
 
-[[location 0]] var<in> position : vec4<f32>;
-[[location 1]] var<in> color : vec4<f32>;
+[[location(0)]] var<in> position : vec4<f32>;
+[[location(1)]] var<in> color : vec4<f32>;
 
-[[builtin position]] var<out> Position : vec4<f32>;
-[[location 0]] var<out> fragColor : vec4<f32>;
+[[builtin(position)]] var<out> Position : vec4<f32>;
+[[location(0)]] var<out> fragColor : vec4<f32>;
 
-fn vtx_main() -> void {
+[[stage(vertex)]]
+fn main() -> void {
   Position = uniforms.modelViewProjectionMatrix * position;
   fragColor = color;
   return;
 }
-entry_point vertex as "main" = vtx_main;
 `,
   fragment: `
-[[location 0]] var<in> fragColor : vec4<f32>;
-[[location 0]] var<out> outColor : vec4<f32>;
+[[location(0)]] var<in> fragColor : vec4<f32>;
+[[location(0)]] var<out> outColor : vec4<f32>;
 
-fn frag_main() -> void {
+[[stage(fragment)]]
+fn main() -> void {
   outColor = fragColor;
   return;
 }
-entry_point fragment as "main" = frag_main;
 `,
 };


### PR DESCRIPTION
Partially addresses #59, but Chrome Canary still has some other bugs that need to addressed.
 
Fixes:
 - Entrypoint syntax
 - GLSL 450 standard library import
 - Decoration syntax

Still broken:
 - Actual usage of standard library functions
 - Indexing into const global variables
 - Textures and samplers