### PR TITLE
Update WGSL samples to use new struct syntax.

### DIFF
--- a/src/examples/animometer.ts
+++ b/src/examples/animometer.ts
@@ -382,11 +382,11 @@ export const glslShaders = {
 
 export const wgslShaders = {
   vertex: `
-type Time = [[block]] struct {
+[[block]] struct Time {
   [[offset(0)]] value : f32;
 };
 
-type Uniforms = [[block]] struct {
+[[block]] struct Uniforms {
   [[offset(0)]] scale : f32;
   [[offset(4)]] offsetX : f32;
   [[offset(8)]] offsetY : f32;

--- a/src/examples/computeBoids.ts
+++ b/src/examples/computeBoids.ts
@@ -367,7 +367,7 @@ fn main() -> void {
   [[offset(0)]] pos : vec2<f32>;
   [[offset(8)]] vel : vec2<f32>;
 };
-[[block]] struct SimParticles {
+[[block]] struct SimParams {
   [[offset(0)]] deltaT : f32;
   [[offset(4)]] rule1Distance : f32;
   [[offset(8)]] rule2Distance : f32;

--- a/src/examples/computeBoids.ts
+++ b/src/examples/computeBoids.ts
@@ -363,11 +363,11 @@ fn main() -> void {
 `,
 
   compute: (numParticles: number) => `
-type Particle = [[block]] struct {
+[[block]] struct Particle {
   [[offset(0)]] pos : vec2<f32>;
   [[offset(8)]] vel : vec2<f32>;
 };
-type SimParams = [[block]] struct {
+[[block]] struct SimParticles {
   [[offset(0)]] deltaT : f32;
   [[offset(4)]] rule1Distance : f32;
   [[offset(8)]] rule2Distance : f32;
@@ -376,7 +376,7 @@ type SimParams = [[block]] struct {
   [[offset(20)]] rule2Scale : f32;
   [[offset(24)]] rule3Scale : f32;
 };
-type Particles = [[block]] struct {
+[[block]] struct Particles {
   [[offset(0)]] particles : [[stride(16)]] array<Particle, ${numParticles}>;
 };
 [[binding(0), set(0)]] var<uniform> params : SimParams;

--- a/src/examples/fractalCube.ts
+++ b/src/examples/fractalCube.ts
@@ -233,7 +233,7 @@ void main() {
 
 export const wgslShaders = {
   vertex: `
-type Uniforms = [[block]] struct {
+[[block]] struct Uniforms {
   [[offset(0)]] modelViewProjectionMatrix : mat4x4<f32>;
 };
 [[binding(0), set(0)]] var<uniform> uniforms : Uniforms;

--- a/src/examples/instancedCube.ts
+++ b/src/examples/instancedCube.ts
@@ -239,7 +239,7 @@ void main() {
 
 export const wgslShaders = {
   vertex: `
-type Uniforms = [[block]] struct {
+[[block]] struct Uniforms {
   [[offset(0)]] modelViewProjectionMatrix : [[stride(64)]] array<mat4x4<f32>, 16>;
 };
 

--- a/src/examples/rotatingCube.ts
+++ b/src/examples/rotatingCube.ts
@@ -211,7 +211,7 @@ void main() {
 
 export const wgslShaders = {
   vertex: `
-type Uniforms = [[block]] struct {
+[[block]] struct Uniforms {
   [[offset(0)]] modelViewProjectionMatrix : mat4x4<f32>;
 };
 

--- a/src/examples/texturedCube.ts
+++ b/src/examples/texturedCube.ts
@@ -251,7 +251,7 @@ void main() {
 
 export const wgslShaders = {
   vertex: `
-type Uniforms = [[block]] struct {
+[[block]] struct Uniforms {
   [[offset(0)]] modelViewProjectionMatrix : mat4x4<f32>;
 };
 [[binding(0), set(0)]] var<uniform> uniforms : Uniforms;

--- a/src/examples/twoCubes.ts
+++ b/src/examples/twoCubes.ts
@@ -243,7 +243,7 @@ void main() {
 
 export const wgslShaders = {
   vertex: `
-type Uniforms = [[block]] struct {
+[[block]] struct Uniforms {
   [[offset(0)]] modelViewProjectionMatrix : mat4x4<f32>;
 };
 


### PR DESCRIPTION
This Cl updates the WGSL examples to use `struct IDENT` instead of `type
IDENT = struct`.