### PR TITLE
Update WGSL to group from set.

### DIFF
--- a/src/pages/samples/animometer.ts
+++ b/src/pages/samples/animometer.ts
@@ -430,8 +430,8 @@ const wgslShaders = {
   [[offset(16)]] scalarOffset : f32;
 };
 
-[[binding(0), set(0)]] var<uniform> time : Time;
-[[binding(0), set(1)]] var<uniform> uniforms : Uniforms;
+[[binding(0), group(0)]] var<uniform> time : Time;
+[[binding(0), group(1)]] var<uniform> uniforms : Uniforms;
 
 [[location(0)]] var<in> position : vec4<f32>;
 [[location(1)]] var<in> color : vec4<f32>;

--- a/src/pages/samples/computeBoids.ts
+++ b/src/pages/samples/computeBoids.ts
@@ -391,9 +391,9 @@ fn main() -> void {
 [[block]] struct Particles {
   [[offset(0)]] particles : [[stride(16)]] array<Particle, ${numParticles}>;
 };
-[[binding(0), set(0)]] var<uniform> params : SimParams;
-[[binding(1), set(0)]] var<storage_buffer> particlesA : Particles;
-[[binding(2), set(0)]] var<storage_buffer> particlesB : Particles;
+[[binding(0), group(0)]] var<uniform> params : SimParams;
+[[binding(1), group(0)]] var<storage_buffer> particlesA : Particles;
+[[binding(2), group(0)]] var<storage_buffer> particlesB : Particles;
 [[builtin(global_invocation_id)]] var<in> GlobalInvocationID : vec3<u32>;
 
 // https://github.com/austinEng/Project6-Vulkan-Flocking/blob/master/data/shaders/computeparticles/particle.comp

--- a/src/pages/samples/fractalCube.ts
+++ b/src/pages/samples/fractalCube.ts
@@ -254,7 +254,7 @@ const wgslShaders = {
 [[block]] struct Uniforms {
   [[offset(0)]] modelViewProjectionMatrix : mat4x4<f32>;
 };
-[[binding(0), set(0)]] var<uniform> uniforms : Uniforms;
+[[binding(0), group(0)]] var<uniform> uniforms : Uniforms;
 
 [[location(0)]] var<in> position : vec4<f32>;
 [[location(1)]] var<in> color : vec4<f32>;
@@ -274,8 +274,8 @@ fn main() -> void {
 `,
 
   fragment: `
-[[binding(1), set(0)]] var<uniform_constant> mySampler: sampler;
-[[binding(2), set(0)]] var<uniform_constant> myTexture: texture_2d<f32>;
+[[binding(1), group(0)]] var<uniform_constant> mySampler: sampler;
+[[binding(2), group(0)]] var<uniform_constant> myTexture: texture_2d<f32>;
 
 [[location(0)]] var<in> fragColor: vec4<f32>;
 [[location(1)]] var<in> fragUV: vec2<f32>;

--- a/src/pages/samples/instancedCube.ts
+++ b/src/pages/samples/instancedCube.ts
@@ -265,7 +265,7 @@ const wgslShaders = {
   [[offset(0)]] modelViewProjectionMatrix : [[stride(64)]] array<mat4x4<f32>, 16>;
 };
 
-[[binding(0), set(0)]] var<uniform> uniforms : Uniforms;
+[[binding(0), group(0)]] var<uniform> uniforms : Uniforms;
 
 [[builtin(instance_idx)]] var<in> instanceIdx : i32;
 [[location(0)]] var<in> position : vec4<f32>;

--- a/src/pages/samples/rotatingCube.ts
+++ b/src/pages/samples/rotatingCube.ts
@@ -217,7 +217,7 @@ const wgslShaders = {
   [[offset(0)]] modelViewProjectionMatrix : mat4x4<f32>;
 };
 
-[[binding(0), set(0)]] var<uniform> uniforms : Uniforms;
+[[binding(0), group(0)]] var<uniform> uniforms : Uniforms;
 
 [[location(0)]] var<in> position : vec4<f32>;
 [[location(1)]] var<in> color : vec4<f32>;

--- a/src/pages/samples/shadowMapping.ts
+++ b/src/pages/samples/shadowMapping.ts
@@ -591,8 +591,8 @@ const wgslShaders = {
   [[offset(0)]] modelMatrix : mat4x4<f32>;
 };
 
-[[set(0), binding(0)]] var<uniform> scene : Scene;
-[[set(1), binding(0)]] var<uniform> model : Model;
+[[group(0), binding(0)]] var<uniform> scene : Scene;
+[[group(1), binding(0)]] var<uniform> model : Model;
 
 [[location(0)]] var<in> position : vec3<f32>;
 
@@ -621,8 +621,8 @@ fn main() -> void {
   [[offset(0)]] modelMatrix : mat4x4<f32>;
 };
 
-[[set(0), binding(0)]] var<uniform> scene : Scene;
-[[set(1), binding(0)]] var<uniform> model : Model;
+[[group(0), binding(0)]] var<uniform> scene : Scene;
+[[group(1), binding(0)]] var<uniform> model : Model;
 
 [[location(0)]] var<in> position : vec3<f32>;
 [[location(1)]] var<in> normal : vec3<f32>;
@@ -657,9 +657,9 @@ fn main() -> void {
   [[offset(128)]] lightPos : vec3<f32>;
 };
 
-[[set(0), binding(0)]] var<uniform> scene : Scene;
-[[set(0), binding(1)]] var<uniform_constant> shadowMap: texture_depth_2d;
-[[set(0), binding(2)]] var<uniform_constant> shadowSampler: sampler_comparison;
+[[group(0), binding(0)]] var<uniform> scene : Scene;
+[[group(0), binding(1)]] var<uniform_constant> shadowMap: texture_depth_2d;
+[[group(0), binding(2)]] var<uniform_constant> shadowSampler: sampler_comparison;
 
 [[location(0)]] var<in> shadowPos : vec3<f32>;
 [[location(1)]] var<in> fragPos : vec3<f32>;

--- a/src/pages/samples/texturedCube.ts
+++ b/src/pages/samples/texturedCube.ts
@@ -277,7 +277,7 @@ const wgslShaders = {
 [[block]] struct Uniforms {
   [[offset(0)]] modelViewProjectionMatrix : mat4x4<f32>;
 };
-[[binding(0), set(0)]] var<uniform> uniforms : Uniforms;
+[[binding(0), group(0)]] var<uniform> uniforms : Uniforms;
 
 [[location(0)]] var<in> position : vec4<f32>;
 [[location(1)]] var<in> uv : vec2<f32>;
@@ -295,8 +295,8 @@ fn main() -> void {
 }
 `,
   fragment: `
-[[binding(1), set(0)]] var<uniform_constant> mySampler: sampler;
-[[binding(2), set(0)]] var<uniform_constant> myTexture: texture_2d<f32>;
+[[binding(1), group(0)]] var<uniform_constant> mySampler: sampler;
+[[binding(2), group(0)]] var<uniform_constant> myTexture: texture_2d<f32>;
 
 [[location(0)]] var<in> fragUV: vec2<f32>;
 [[location(1)]] var<in> fragPosition: vec4<f32>;

--- a/src/pages/samples/twoCubes.ts
+++ b/src/pages/samples/twoCubes.ts
@@ -273,7 +273,7 @@ const wgslShaders = {
   [[offset(0)]] modelViewProjectionMatrix : mat4x4<f32>;
 };
 
-[[binding(0), set(0)]] var<uniform> uniforms : Uniforms;
+[[binding(0), group(0)]] var<uniform> uniforms : Uniforms;
 
 [[location(0)]] var<in> position : vec4<f32>;
 [[location(1)]] var<in> color : vec4<f32>;

--- a/src/pages/samples/videoUploading.ts
+++ b/src/pages/samples/videoUploading.ts
@@ -187,8 +187,8 @@ void main() {
 `,
 
   fragment: `
-[[binding(0), set(0)]] var<uniform_constant> mySampler: sampler;
-[[binding(1), set(0)]] var<uniform_constant> myTexture: texture_2d<f32>;
+[[binding(0), group(0)]] var<uniform_constant> mySampler: sampler;
+[[binding(1), group(0)]] var<uniform_constant> myTexture: texture_2d<f32>;
 
 [[location(0)]] var<in> fragUV : vec2<f32>;
 [[location(0)]] var<out> outColor : vec4<f32>;


### PR DESCRIPTION
This CL updates the WGSL examples from the deprecated `set` decoration
to the new `group` decoration.