### PR TITLE
Update index names to match WGSL spec.

### DIFF
--- a/src/pages/samples/helloTriangle.ts
+++ b/src/pages/samples/helloTriangle.ts
@@ -98,7 +98,7 @@ const pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
     vec2<f32>(0.5, -0.5));
 
 [[builtin(position)]] var<out> Position : vec4<f32>;
-[[builtin(vertex_idx)]] var<in> VertexIndex : i32;
+[[builtin(vertex_index)]] var<in> VertexIndex : i32;
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/pages/samples/helloTriangleMSAA.ts
+++ b/src/pages/samples/helloTriangleMSAA.ts
@@ -114,7 +114,7 @@ const pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
     vec2<f32>(0.5, -0.5));
 
 [[builtin(position)]] var<out> Position : vec4<f32>;
-[[builtin(vertex_idx)]] var<in> VertexIndex : i32;
+[[builtin(vertex_index)]] var<in> VertexIndex : i32;
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/pages/samples/instancedCube.ts
+++ b/src/pages/samples/instancedCube.ts
@@ -267,7 +267,7 @@ const wgslShaders = {
 
 [[binding(0), set(0)]] var<uniform> uniforms : Uniforms;
 
-[[builtin(instance_idx)]] var<in> instanceIdx : i32;
+[[builtin(instance_index)]] var<in> instanceIdx : i32;
 [[location(0)]] var<in> position : vec4<f32>;
 [[location(1)]] var<in> color : vec4<f32>;
 


### PR DESCRIPTION
This CL updates the `vertex_idx` and `instance_idx` builtins to match
the new `vertex_index` and `instance_index` names.