### PR TITLE
Remove explicit storage class from samplers/textures

### DIFF
--- a/src/pages/samples/fractalCube.ts
+++ b/src/pages/samples/fractalCube.ts
@@ -274,8 +274,8 @@ fn main() -> void {
 `,
 
   fragment: `
-[[binding(1), group(0)]] var<uniform_constant> mySampler: sampler;
-[[binding(2), group(0)]] var<uniform_constant> myTexture: texture_2d<f32>;
+[[binding(1), group(0)]] var mySampler: sampler;
+[[binding(2), group(0)]] var myTexture: texture_2d<f32>;
 
 [[location(0)]] var<in> fragColor: vec4<f32>;
 [[location(1)]] var<in> fragUV: vec2<f32>;

--- a/src/pages/samples/shadowMapping.ts
+++ b/src/pages/samples/shadowMapping.ts
@@ -658,8 +658,8 @@ fn main() -> void {
 };
 
 [[group(0), binding(0)]] var<uniform> scene : Scene;
-[[group(0), binding(1)]] var<uniform_constant> shadowMap: texture_depth_2d;
-[[group(0), binding(2)]] var<uniform_constant> shadowSampler: sampler_comparison;
+[[group(0), binding(1)]] var shadowMap: texture_depth_2d;
+[[group(0), binding(2)]] var shadowSampler: sampler_comparison;
 
 [[location(0)]] var<in> shadowPos : vec3<f32>;
 [[location(1)]] var<in> fragPos : vec3<f32>;

--- a/src/pages/samples/texturedCube.ts
+++ b/src/pages/samples/texturedCube.ts
@@ -295,8 +295,8 @@ fn main() -> void {
 }
 `,
   fragment: `
-[[binding(1), group(0)]] var<uniform_constant> mySampler: sampler;
-[[binding(2), group(0)]] var<uniform_constant> myTexture: texture_2d<f32>;
+[[binding(1), group(0)]] var mySampler: sampler;
+[[binding(2), group(0)]] var myTexture: texture_2d<f32>;
 
 [[location(0)]] var<in> fragUV: vec2<f32>;
 [[location(1)]] var<in> fragPosition: vec4<f32>;

--- a/src/pages/samples/videoUploading.ts
+++ b/src/pages/samples/videoUploading.ts
@@ -187,8 +187,8 @@ void main() {
 `,
 
   fragment: `
-[[binding(0), group(0)]] var<uniform_constant> mySampler: sampler;
-[[binding(1), group(0)]] var<uniform_constant> myTexture: texture_2d<f32>;
+[[binding(0), group(0)]] var mySampler: sampler;
+[[binding(1), group(0)]] var myTexture: texture_2d<f32>;
 
 [[location(0)]] var<in> fragUV : vec2<f32>;
 [[location(0)]] var<out> outColor : vec4<f32>;


### PR DESCRIPTION
Tint automatically infers a storage class of `handle` for these types of variable, as per the WGSL spec. Explicitly specifying a storage class for them will soon become an error.

Tested with Chrome 90.0.4414.0 (Official Build) canary (x86_64), on macOS, although it seems the "Fractal Cube" and "Video Uploading" samples are not using the WGSL shaders yet.