### PR TITLE
Use new WGSL entry point IO syntax

### DIFF
--- a/src/pages/samples/animometer.ts
+++ b/src/pages/samples/animometer.ts
@@ -433,14 +433,14 @@ const wgslShaders = {
 [[binding(0), group(0)]] var<uniform> time : Time;
 [[binding(0), group(1)]] var<uniform> uniforms : Uniforms;
 
-[[location(0)]] var<in> position : vec4<f32>;
-[[location(1)]] var<in> color : vec4<f32>;
-
-[[builtin(position)]] var<out> Position : vec4<f32>;
-[[location(0)]] var<out> v_color : vec4<f32>;
+struct VertexOutput {
+  [[builtin(position)]] Position : vec4<f32>;
+  [[location(0)]] v_color : vec4<f32>;
+};
 
 [[stage(vertex)]]
-fn main() -> void {
+fn main([[location(0)]] position : vec4<f32>,
+        [[location(1)]] color : vec4<f32>) -> VertexOutput {
     var fade : f32 = (uniforms.scalarOffset + time.value * uniforms.scalar / 10.0) % 1.0;
     if (fade < 0.5) {
         fade = fade * 2.0;
@@ -454,20 +454,17 @@ fn main() -> void {
     var yrot : f32 = xpos * sin(angle) + ypos * cos(angle);
     xpos = xrot + uniforms.offsetX;
     ypos = yrot + uniforms.offsetY;
-    v_color = vec4<f32>(fade, 1.0 - fade, 0.0, 1.0) + color;
-    Position = vec4<f32>(xpos, ypos, 0.0, 1.0);
-    return;
+    var output : VertexOutput;
+    output.v_color = vec4<f32>(fade, 1.0 - fade, 0.0, 1.0) + color;
+    output.Position = vec4<f32>(xpos, ypos, 0.0, 1.0);
+    return output;
 }
 `,
 
   fragment: `
-[[location(0)]] var<in> v_color : vec4<f32>;
-[[location(0)]] var<out> outColor : vec4<f32>;
-
 [[stage(fragment)]]
-fn main() -> void {
-  outColor = v_color;
-  return;
+fn main([[location(0)]] v_color : vec4<f32>) -> [[location(0)]] vec4<f32> {
+  return v_color;
 }
 `,
 };

--- a/src/pages/samples/computeBoids.ts
+++ b/src/pages/samples/computeBoids.ts
@@ -344,29 +344,22 @@ void main() {
 
 const wgslShaders = {
   vertex: `
-[[location(0)]] var<in> a_particlePos : vec2<f32>;
-[[location(1)]] var<in> a_particleVel : vec2<f32>;
-[[location(2)]] var<in> a_pos : vec2<f32>;
-[[builtin(position)]] var<out> Position : vec4<f32>;
-
 [[stage(vertex)]]
-fn main() -> void {
+fn main([[location(0)]] a_particlePos : vec2<f32>,
+        [[location(1)]] a_particleVel : vec2<f32>,
+        [[location(2)]] a_pos : vec2<f32>) -> [[builtin(position)]] vec4<f32> {
   var angle : f32 = -atan2(a_particleVel.x, a_particleVel.y);
   var pos : vec2<f32> = vec2<f32>(
       (a_pos.x * cos(angle)) - (a_pos.y * sin(angle)),
       (a_pos.x * sin(angle)) + (a_pos.y * cos(angle)));
-  Position = vec4<f32>(pos + a_particlePos, 0.0, 1.0);
-  return;
+  return vec4<f32>(pos + a_particlePos, 0.0, 1.0);
 }
 `,
 
   fragment: `
-[[location(0)]] var<out> fragColor : vec4<f32>;
-
 [[stage(fragment)]]
-fn main() -> void {
-  fragColor = vec4<f32>(1.0, 1.0, 1.0, 1.0);
-  return;
+fn main() -> [[location(0)]] vec4<f32> {
+  return vec4<f32>(1.0, 1.0, 1.0, 1.0);
 }
 `,
 
@@ -390,11 +383,10 @@ fn main() -> void {
 [[binding(0), group(0)]] var<uniform> params : SimParams;
 [[binding(1), group(0)]] var<storage_buffer> particlesA : Particles;
 [[binding(2), group(0)]] var<storage_buffer> particlesB : Particles;
-[[builtin(global_invocation_id)]] var<in> GlobalInvocationID : vec3<u32>;
 
 // https://github.com/austinEng/Project6-Vulkan-Flocking/blob/master/data/shaders/computeparticles/particle.comp
 [[stage(compute)]]
-fn main() -> void {
+fn main([[builtin(global_invocation_id)]] GlobalInvocationID : vec3<u32>) -> void {
   var index : u32 = GlobalInvocationID.x;
   if (index >= ${numParticles}u) {
     return;

--- a/src/pages/samples/fractalCube.ts
+++ b/src/pages/samples/fractalCube.ts
@@ -251,20 +251,25 @@ const wgslShaders = {
 };
 [[binding(0), group(0)]] var<uniform> uniforms : Uniforms;
 
-[[location(0)]] var<in> position : vec4<f32>;
-[[location(1)]] var<in> color : vec4<f32>;
-[[location(2)]] var<in> uv : vec2<f32>;
+struct VertexInput {
+  [[location(0)]] position : vec4<f32>;
+  [[location(1)]] color : vec4<f32>;
+  [[location(2)]] uv : vec2<f32>;
+};
 
-[[builtin(position)]] var<out> Position : vec4<f32>;
-[[location(0)]] var<out> fragColor : vec4<f32>;
-[[location(1)]] var<out> fragUV: vec2<f32>;
+struct VertexOutput {
+  [[builtin(position)]] Position : vec4<f32>;
+  [[location(0)]] fragColor : vec4<f32>;
+  [[location(1)]] fragUV: vec2<f32>;
+};
 
 [[stage(vertex)]]
-fn main() -> void {
-  Position = uniforms.modelViewProjectionMatrix * position;
-  fragColor = color;
-  fragUV = uv;
-  return;
+fn main(input : VertexInput) -> VertexOutput {
+  var output : VertexOutput;
+  output.Position = uniforms.modelViewProjectionMatrix * input.position;
+  output.fragColor = input.color;
+  output.fragUV = input.uv;
+  return output;
 }
 `,
 
@@ -272,16 +277,16 @@ fn main() -> void {
 [[binding(1), group(0)]] var mySampler: sampler;
 [[binding(2), group(0)]] var myTexture: texture_2d<f32>;
 
-[[location(0)]] var<in> fragColor: vec4<f32>;
-[[location(1)]] var<in> fragUV: vec2<f32>;
-[[location(0)]] var<out> outColor : vec4<f32>;
+struct FragmentInput {
+  [[location(0)]] fragColor: vec4<f32>;
+  [[location(1)]] fragUV: vec2<f32>;
+};
 
 [[stage(fragment)]]
-fn main() -> void {
-  var texColor : vec4<f32> = textureSample(myTexture, mySampler, fragUV * 0.8 + 0.1) * fragPosition;
+fn main(input : FragmentInput) -> [[location(0)]] vec4<f32> {
+  var texColor : vec4<f32> = textureSample(myTexture, mySampler, input.fragUV * 0.8 + 0.1) * fragPosition;
   var f : f32 = f32(length(texColor.rgb - vec3(0.5, 0.5, 0.5)) < 0.01);
-  outColor = mix(texColor, fragColor, f);
-  return;
+  return mix(texColor, input.fragColor, f);
 }
 `,
 };

--- a/src/pages/samples/helloTriangle.ts
+++ b/src/pages/samples/helloTriangle.ts
@@ -97,22 +97,16 @@ const pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
     vec2<f32>(-0.5, -0.5),
     vec2<f32>(0.5, -0.5));
 
-[[builtin(position)]] var<out> Position : vec4<f32>;
-[[builtin(vertex_index)]] var<in> VertexIndex : u32;
-
 [[stage(vertex)]]
-fn main() -> void {
-  Position = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
-  return;
+fn main([[builtin(vertex_index)]] VertexIndex : u32)
+     -> [[builtin(position)]] vec4<f32> {
+  return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
 }
 `,
   fragment: `
-[[location(0)]] var<out> outColor : vec4<f32>;
-
 [[stage(fragment)]]
-fn main() -> void {
-  outColor = vec4<f32>(1.0, 0.0, 0.0, 1.0);
-  return;
+fn main() -> [[location(0)]] vec4<f32> {
+  return vec4<f32>(1.0, 0.0, 0.0, 1.0);
 }
 `,
 };

--- a/src/pages/samples/helloTriangleMSAA.ts
+++ b/src/pages/samples/helloTriangleMSAA.ts
@@ -113,22 +113,16 @@ const pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
     vec2<f32>(-0.5, -0.5),
     vec2<f32>(0.5, -0.5));
 
-[[builtin(position)]] var<out> Position : vec4<f32>;
-[[builtin(vertex_index)]] var<in> VertexIndex : u32;
-
 [[stage(vertex)]]
-fn main() -> void {
-  Position = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
-  return;
+fn main([[builtin(vertex_index)]] VertexIndex : u32)
+     -> [[builtin(position)]] vec4<f32> {
+  return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
 }
 `,
   fragment: `
-[[location(0)]] var<out> outColor : vec4<f32>;
-
 [[stage(fragment)]]
-fn main() -> void {
-  outColor = vec4<f32>(1.0, 0.0, 0.0, 1.0);
-  return;
+fn main() -> [[location(0)]] vec4<f32> {
+  return vec4<f32>(1.0, 0.0, 0.0, 1.0);
 }
 `,
 };

--- a/src/pages/samples/instancedCube.ts
+++ b/src/pages/samples/instancedCube.ts
@@ -262,28 +262,25 @@ const wgslShaders = {
 
 [[binding(0), group(0)]] var<uniform> uniforms : Uniforms;
 
-[[builtin(instance_index)]] var<in> instanceIdx : u32;
-[[location(0)]] var<in> position : vec4<f32>;
-[[location(1)]] var<in> color : vec4<f32>;
-
-[[builtin(position)]] var<out> Position : vec4<f32>;
-[[location(0)]] var<out> fragColor : vec4<f32>;
+struct VertexOutput {
+  [[builtin(position)]] Position : vec4<f32>;
+  [[location(0)]] fragColor : vec4<f32>;
+};
 
 [[stage(vertex)]]
-fn main() -> void {
-  Position = uniforms.modelViewProjectionMatrix[instanceIdx] * position;
-  fragColor = color;
-  return;
+fn main([[builtin(instance_index)]] instanceIdx : u32,
+        [[location(0)]] position : vec4<f32>,
+        [[location(1)]] color : vec4<f32>) -> VertexOutput {
+  var output : VertexOutput;
+  output.Position = uniforms.modelViewProjectionMatrix[instanceIdx] * position;
+  output.fragColor = color;
+  return output;
 }
 `,
   fragment: `
-[[location(0)]] var<in> fragColor : vec4<f32>;
-[[location(0)]] var<out> outColor : vec4<f32>;
-
 [[stage(fragment)]]
-fn main() -> void {
-  outColor = fragColor;
-  return;
+fn main([[location(0)]] fragColor : vec4<f32>) -> [[location(0)]] vec4<f32> {
+  return fragColor;
 }
 `,
 };

--- a/src/pages/samples/rotatingCube.ts
+++ b/src/pages/samples/rotatingCube.ts
@@ -214,27 +214,21 @@ const wgslShaders = {
 
 [[binding(0), group(0)]] var<uniform> uniforms : Uniforms;
 
-[[location(0)]] var<in> position : vec4<f32>;
-[[location(1)]] var<in> color : vec4<f32>;
-
-[[builtin(position)]] var<out> Position : vec4<f32>;
-[[location(0)]] var<out> fragColor : vec4<f32>;
+struct VertexOutput {
+  [[builtin(position)]] Position : vec4<f32>;
+  [[location(0)]] fragColor : vec4<f32>;
+};
 
 [[stage(vertex)]]
-fn main() -> void {
-  Position = uniforms.modelViewProjectionMatrix * position;
-  fragColor = color;
-  return;
+fn main([[location(0)]] position : vec4<f32>,
+        [[location(1)]] color : vec4<f32>) -> VertexOutput {
+  return VertexOutput(uniforms.modelViewProjectionMatrix * position, color);
 }
 `,
   fragment: `
-[[location(0)]] var<in> fragColor : vec4<f32>;
-[[location(0)]] var<out> outColor : vec4<f32>;
-
 [[stage(fragment)]]
-fn main() -> void {
-  outColor = fragColor;
-  return;
+fn main([[location(0)]] fragColor : vec4<f32>) -> [[location(0)]] vec4<f32> {
+  return fragColor;
 }
 `,
 };

--- a/src/pages/samples/texturedCube.ts
+++ b/src/pages/samples/texturedCube.ts
@@ -281,33 +281,30 @@ const wgslShaders = {
 };
 [[binding(0), group(0)]] var<uniform> uniforms : Uniforms;
 
-[[location(0)]] var<in> position : vec4<f32>;
-[[location(1)]] var<in> uv : vec2<f32>;
-
-[[builtin(position)]] var<out> Position : vec4<f32>;
-[[location(0)]] var<out> fragUV : vec2<f32>;
-[[location(1)]] var<out> fragPosition: vec4<f32>;
+struct VertexOutput {
+  [[builtin(position)]] Position : vec4<f32>;
+  [[location(0)]] fragUV : vec2<f32>;
+  [[location(1)]] fragPosition: vec4<f32>;
+};
 
 [[stage(vertex)]]
-fn main() -> void {
-  fragPosition = 0.5 * (position + vec4<f32>(1.0, 1.0, 1.0, 1.0));
-  Position = uniforms.modelViewProjectionMatrix * position;
-  fragUV = uv;
-  return;
+fn main([[location(0)]] position : vec4<f32>,
+        [[location(1)]] uv : vec2<f32> ) -> VertexOutput {
+  var output : VertexOutput;
+  output.fragPosition = 0.5 * (position + vec4<f32>(1.0, 1.0, 1.0, 1.0));
+  output.Position = uniforms.modelViewProjectionMatrix * position;
+  output.fragUV = uv;
+  return output;
 }
 `,
   fragment: `
 [[binding(1), group(0)]] var mySampler: sampler;
 [[binding(2), group(0)]] var myTexture: texture_2d<f32>;
 
-[[location(0)]] var<in> fragUV: vec2<f32>;
-[[location(1)]] var<in> fragPosition: vec4<f32>;
-[[location(0)]] var<out> outColor : vec4<f32>;
-
 [[stage(fragment)]]
-fn main() -> void {
-  outColor =  textureSample(myTexture, mySampler, fragUV) * fragPosition;
-  return;
+fn main([[location(0)]] fragUV: vec2<f32>,
+        [[location(1)]] fragPosition: vec4<f32>) -> [[location(0)]] vec4<f32> {
+  return textureSample(myTexture, mySampler, fragUV) * fragPosition;
 }
 `,
 };

--- a/src/pages/samples/twoCubes.ts
+++ b/src/pages/samples/twoCubes.ts
@@ -270,27 +270,21 @@ const wgslShaders = {
 
 [[binding(0), group(0)]] var<uniform> uniforms : Uniforms;
 
-[[location(0)]] var<in> position : vec4<f32>;
-[[location(1)]] var<in> color : vec4<f32>;
-
-[[builtin(position)]] var<out> Position : vec4<f32>;
-[[location(0)]] var<out> fragColor : vec4<f32>;
+struct VertexOutput {
+  [[builtin(position)]] Position : vec4<f32>;
+  [[location(0)]] fragColor : vec4<f32>;
+};
 
 [[stage(vertex)]]
-fn main() -> void {
-  Position = uniforms.modelViewProjectionMatrix * position;
-  fragColor = color;
-  return;
+fn main([[location(0)]] position : vec4<f32>,
+        [[location(1)]] color : vec4<f32>) -> VertexOutput {
+  return VertexOutput(uniforms.modelViewProjectionMatrix * position, color);
 }
 `,
   fragment: `
-[[location(0)]] var<in> fragColor : vec4<f32>;
-[[location(0)]] var<out> outColor : vec4<f32>;
-
 [[stage(fragment)]]
-fn main() -> void {
-  outColor = fragColor;
-  return;
+fn main([[location(0)]] fragColor : vec4<f32>) -> [[location(0)]] vec4<f32> {
+  return fragColor;
 }
 `,
 };

--- a/src/pages/samples/videoUploading.ts
+++ b/src/pages/samples/videoUploading.ts
@@ -182,16 +182,19 @@ void main() {
 
 const wgslShaders = {
   vertex: `
-[[location(0)]] var<in> position : vec3<f32>;
-[[location(1)]] var<in> uv : vec2<f32>;
+struct VertexInput {
+  [[location(0)]] position : vec3<f32>;
+  [[location(1)]] uv : vec2<f32>;
+};
 
-[[location(0)]] var<out> fragUV : vec2<f32>;
-[[builtin(position)]] var<out> Position : vec4<f32>;
+struct VertexOutput {
+  [[builtin(position)]] Position : vec4<f32>;
+  [[location(0)]] fragUV : vec2<f32>;
+};
 
 [[stage(vertex)]]
-fn main() -> void {
-  Position = vec4<f32>(position, 1.0);
-  fragUV = uv;
+fn main(input : VertexInput) -> VertexOutput {
+  return VertexOutput(vec4<f32>(input.position, 1.0), input.uv);
 }
 `,
 
@@ -199,13 +202,9 @@ fn main() -> void {
 [[binding(0), group(0)]] var mySampler: sampler;
 [[binding(1), group(0)]] var myTexture: texture_2d<f32>;
 
-[[location(0)]] var<in> fragUV : vec2<f32>;
-[[location(0)]] var<out> outColor : vec4<f32>;
-
 [[stage(fragment)]]
-fn main() -> void {
-  outColor =  textureSample(myTexture, mySampler, fragUV);
-  return;
+fn main([[location(0)]] fragUV : vec2<f32>) -> [[location(0)]] vec4<f32> {
+  return textureSample(myTexture, mySampler, fragUV);
 }
 `,
 };


### PR DESCRIPTION
WGSL now uses entry point function parameters and return values for entry point IO, instead of module-scope variables.

I made some fairly arbitrary choices about when to use structures for input parameters, and on how to name/format things. Please feel free to suggest/make changes as desired.

Tested with latest Chrome Canary on macOS.