### PR TITLE
Remove unnecessary compute dispatch call in the image blur example.

### DIFF
--- a/src/pages/samples/imageBlur.ts
+++ b/src/pages/samples/imageBlur.ts
@@ -274,7 +274,6 @@ async function init(canvas: HTMLCanvasElement, _useWGSL: boolean, gui?: GUI) {
       Math.ceil(srcWidth / blockDim),
       Math.ceil(srcHeight / batch[1])
     );
-    computePass.dispatch(2, Math.ceil(srcHeight / batch[1]));
 
     computePass.setBindGroup(1, computeBindGroup1);
     computePass.dispatch(


### PR DESCRIPTION
I might be missing something, but I think the `computePass.dispatch(2, Math.ceil(srcHeight / batch[1]));` is just redoing some of the computation from the previous dispatch call.  Removing this line seems to have no effect on the output.