### PR TITLE
Fix shadow mapping diffuse component to use max function

### DIFF
--- a/src/pages/samples/shadowMapping.ts
+++ b/src/pages/samples/shadowMapping.ts
@@ -494,24 +494,23 @@ let ambientFactor : f32 = 0.2;
 fn main(input : FragmentInput) -> [[location(0)]] vec4<f32> {
   // Percentage-closer filtering. Sample texels in the region
   // to smooth the result.
-  var shadowFactor : f32 = 0.0;
+  var visibility : f32 = 0.0;
   for (var y : i32 = -1 ; y <= 1 ; y = y + 1) {
       for (var x : i32 = -1 ; x <= 1 ; x = x + 1) {
         let offset : vec2<f32> = vec2<f32>(
           f32(x) * ${1 / shadowDepthTextureSize},
           f32(y) * ${1 / shadowDepthTextureSize});
 
-        shadowFactor = shadowFactor + textureSampleCompare(
+          visibility = visibility + textureSampleCompare(
           shadowMap, shadowSampler,
           input.shadowPos.xy + offset, input.shadowPos.z - 0.007);
       }
   }
+  visibility = visibility / 9.0;
 
-  shadowFactor = ambientFactor + shadowFactor / 9.0;
+  let lambertFactor : f32 = max(dot(normalize(scene.lightPos - input.fragPos), input.fragNorm), 0.0);
 
-  let lambertFactor : f32 = abs(dot(normalize(scene.lightPos - input.fragPos), input.fragNorm));
-
-  let lightingFactor : f32 = min(shadowFactor * lambertFactor, 1.0);
+  let lightingFactor : f32 = min(ambientFactor + visibility * lambertFactor, 1.0);
   return vec4<f32>(lightingFactor * albedo, 1.0);
 }
 `,


### PR DESCRIPTION
Use the max function to make sure the diffuse component never becomes negative.