### PR TITLE
Updates for WGSL spec changes

### DIFF
--- a/src/sample/computeBoids/updateSprites.wgsl
+++ b/src/sample/computeBoids/updateSprites.wgsl
@@ -15,8 +15,8 @@ struct Particle {
   particles : [[stride(16)]] array<Particle>;
 };
 [[binding(0), group(0)]] var<uniform> params : SimParams;
-[[binding(1), group(0)]] var<storage> particlesA : [[access(read)]] Particles;
-[[binding(2), group(0)]] var<storage> particlesB : [[access(read_write)]] Particles;
+[[binding(1), group(0)]] var<storage, read> particlesA : Particles;
+[[binding(2), group(0)]] var<storage, read_write> particlesB : Particles;
 
 // https://github.com/austinEng/Project6-Vulkan-Flocking/blob/master/data/shaders/computeparticles/particle.comp
 [[stage(compute), workgroup_size(64)]]
@@ -33,7 +33,7 @@ fn main([[builtin(global_invocation_id)]] GlobalInvocationID : vec3<u32>) {
   var pos : vec2<f32>;
   var vel : vec2<f32>;
 
-  for (var i : u32 = 0u; i < arrayLength(particlesA.particles); i = i + 1u) {
+  for (var i : u32 = 0u; i < arrayLength(&particlesA.particles); i = i + 1u) {
     if (i == index) {
       continue;
     }

--- a/src/sample/deferredRendering/fragmentDeferredRendering.wgsl
+++ b/src/sample/deferredRendering/fragmentDeferredRendering.wgsl
@@ -11,7 +11,7 @@ struct LightData {
 [[block]] struct LightsBuffer {
   lights: array<LightData>;
 };
-[[group(1), binding(0)]] var<storage> lightsBuffer: [[access(read)]] LightsBuffer;
+[[group(1), binding(0)]] var<storage, read> lightsBuffer: LightsBuffer;
 
 [[block]] struct Config {
   numLights : u32;

--- a/src/sample/deferredRendering/lightUpdate.wgsl
+++ b/src/sample/deferredRendering/lightUpdate.wgsl
@@ -6,7 +6,7 @@ struct LightData {
 [[block]] struct LightsBuffer {
   lights: array<LightData>;
 };
-[[group(0), binding(0)]] var<storage> lightsBuffer: [[access(read_write)]] LightsBuffer;
+[[group(0), binding(0)]] var<storage, read_write> lightsBuffer: LightsBuffer;
 
 [[block]] struct Config {
   numLights : u32;
@@ -27,7 +27,7 @@ fn main([[builtin(global_invocation_id)]] GlobalInvocationID : vec3<u32>) {
   }
 
   lightsBuffer.lights[index].position.y = lightsBuffer.lights[index].position.y - 0.5 - 0.003 * (f32(index) - 64.0 * floor(f32(index) / 64.0));
-  
+
   if (lightsBuffer.lights[index].position.y < lightExtent.min.y) {
     lightsBuffer.lights[index].position.y = lightExtent.max.y;
   }

--- a/src/sample/imageBlur/blur.wgsl
+++ b/src/sample/imageBlur/blur.wgsl
@@ -6,7 +6,7 @@
 [[group(0), binding(0)]] var samp : sampler;
 [[group(0), binding(1)]] var<uniform> params : Params;
 [[group(1), binding(1)]] var inputTex : texture_2d<f32>;
-[[group(1), binding(2)]] var outputTex : [[access(write)]] texture_storage_2d<rgba8unorm>;
+[[group(1), binding(2)]] var outputTex : texture_storage_2d<rgba8unorm, write>;
 
 [[block]] struct Flip {
   value : u32;


### PR DESCRIPTION
Remove access control decorations.
See https://github.com/gpuweb/gpuweb/pull/1735

arrayLength() now takes a pointer to the array.
See https://github.com/gpuweb/gpuweb/pull/1619