### PR TITLE
wgsl: Fixes for new validation failures

### DIFF
--- a/src/pages/samples/reversedZ.ts
+++ b/src/pages/samples/reversedZ.ts
@@ -800,13 +800,13 @@ fn main([[builtin(position)]] coord : vec4<f32>,
 }
 `,
   vertexTextureQuad: `
-let pos : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
-  vec2<f32>(-1.0, -1.0), vec2<f32>(1.0, -1.0), vec2<f32>(-1.0, 1.0),
-  vec2<f32>(-1.0, 1.0), vec2<f32>(1.0, -1.0), vec2<f32>(1.0, 1.0));
-
 [[stage(vertex)]]
 fn main([[builtin(vertex_index)]] VertexIndex : u32)
      -> [[builtin(position)]] vec4<f32> {
+  var pos : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
+    vec2<f32>(-1.0, -1.0), vec2<f32>(1.0, -1.0), vec2<f32>(-1.0, 1.0),
+    vec2<f32>(-1.0, 1.0), vec2<f32>(1.0, -1.0), vec2<f32>(1.0, 1.0));
+
   return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
 }
 `,

--- a/src/sample/deferredRendering/vertexTextureQuad.wgsl
+++ b/src/sample/deferredRendering/vertexTextureQuad.wgsl
@@ -1,9 +1,9 @@
-let pos : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
-    vec2<f32>(-1.0, -1.0), vec2<f32>(1.0, -1.0), vec2<f32>(-1.0, 1.0),
-    vec2<f32>(-1.0, 1.0), vec2<f32>(1.0, -1.0), vec2<f32>(1.0, 1.0));
-
 [[stage(vertex)]]
 fn main([[builtin(vertex_index)]] VertexIndex : u32)
         -> [[builtin(position)]] vec4<f32> {
+    var pos : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0, -1.0), vec2<f32>(1.0, -1.0), vec2<f32>(-1.0, 1.0),
+        vec2<f32>(-1.0, 1.0), vec2<f32>(1.0, -1.0), vec2<f32>(1.0, 1.0));
+
     return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
 }

--- a/src/shaders/fullscreenTexturedQuad.wgsl
+++ b/src/shaders/fullscreenTexturedQuad.wgsl
@@ -6,24 +6,24 @@ struct VertexOutput {
   [[location(0)]] fragUV : vec2<f32>;
 };
 
-let pos : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
-    vec2<f32>( 1.0,  1.0),
-    vec2<f32>( 1.0, -1.0),
-    vec2<f32>(-1.0, -1.0),
-    vec2<f32>( 1.0,  1.0),
-    vec2<f32>(-1.0, -1.0),
-    vec2<f32>(-1.0,  1.0));
-
-let uv : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
-    vec2<f32>(1.0, 0.0),
-    vec2<f32>(1.0, 1.0),
-    vec2<f32>(0.0, 1.0),
-    vec2<f32>(1.0, 0.0),
-    vec2<f32>(0.0, 1.0),
-    vec2<f32>(0.0, 0.0));
-
 [[stage(vertex)]]
 fn vert_main([[builtin(vertex_index)]] VertexIndex : u32) -> VertexOutput {
+  var pos : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
+      vec2<f32>( 1.0,  1.0),
+      vec2<f32>( 1.0, -1.0),
+      vec2<f32>(-1.0, -1.0),
+      vec2<f32>( 1.0,  1.0),
+      vec2<f32>(-1.0, -1.0),
+      vec2<f32>(-1.0,  1.0));
+
+  var uv : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
+      vec2<f32>(1.0, 0.0),
+      vec2<f32>(1.0, 1.0),
+      vec2<f32>(0.0, 1.0),
+      vec2<f32>(1.0, 0.0),
+      vec2<f32>(0.0, 1.0),
+      vec2<f32>(0.0, 0.0));
+
   var output : VertexOutput;
   output.Position = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
   output.fragUV = uv[VertexIndex];

--- a/src/shaders/triangle.vert.wgsl
+++ b/src/shaders/triangle.vert.wgsl
@@ -1,10 +1,10 @@
-let pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
-    vec2<f32>(0.0, 0.5),
-    vec2<f32>(-0.5, -0.5),
-    vec2<f32>(0.5, -0.5));
-
 [[stage(vertex)]]
 fn main([[builtin(vertex_index)]] VertexIndex : u32)
      -> [[builtin(position)]] vec4<f32> {
+  var pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
+      vec2<f32>(0.0, 0.5),
+      vec2<f32>(-0.5, -0.5),
+      vec2<f32>(0.5, -0.5));
+
   return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
 }


### PR DESCRIPTION
Values of array and matrix can now only be indexed by a constant value.
Dynamic indexing requires the value to be held in memory.

See: gpuweb/gpuweb#1782