### PR TITLE
wgsl: Add workgroup_size() decoration on compute shader

### DIFF
--- a/src/sample/deferredRendering/lightUpdate.wgsl
+++ b/src/sample/deferredRendering/lightUpdate.wgsl
@@ -19,7 +19,7 @@ struct LightData {
 };
 [[group(0), binding(2)]] var<uniform> lightExtent: LightExtent;
 
-[[stage(compute), workgroup_size(16)]]
+[[stage(compute), workgroup_size(1)]]
 fn main([[builtin(global_invocation_id)]] GlobalInvocationID : vec3<u32>) {
   var index = GlobalInvocationID.x;
   if (index >= config.numLights) {

--- a/src/sample/deferredRendering/lightUpdate.wgsl
+++ b/src/sample/deferredRendering/lightUpdate.wgsl
@@ -19,7 +19,7 @@ struct LightData {
 };
 [[group(0), binding(2)]] var<uniform> lightExtent: LightExtent;
 
-[[stage(compute)]]
+[[stage(compute), workgroup_size(16)]]
 fn main([[builtin(global_invocation_id)]] GlobalInvocationID : vec3<u32>) {
   var index = GlobalInvocationID.x;
   if (index >= config.numLights) {


### PR DESCRIPTION
This is now required by validation.

16 is a number I made up. It is larger than 1, which was the old default.

Note: I haven't actually checked that `workgroup_size(16)` actually behaves correctly.