### PR TITLE
Fix round behavior

### DIFF
--- a/src/sample/deferredRendering/fragmentDeferredRendering.wgsl
+++ b/src/sample/deferredRendering/fragmentDeferredRendering.wgsl
@@ -30,7 +30,7 @@ fn main([[builtin(position)]] coord : vec4<f32>)
 
   var position = textureLoad(
     gBufferPosition,
-    vec2<i32>(round(coord.xy)),
+    vec2<i32>(floor(coord.xy)),
     0
   ).xyz;
 
@@ -40,13 +40,13 @@ fn main([[builtin(position)]] coord : vec4<f32>)
 
   var normal = textureLoad(
     gBufferNormal,
-    vec2<i32>(round(coord.xy)),
+    vec2<i32>(floor(coord.xy)),
     0
   ).xyz;
 
   var albedo = textureLoad(
     gBufferAlbedo,
-    vec2<i32>(round(coord.xy)),
+    vec2<i32>(floor(coord.xy)),
     0
   ).rgb;
 

--- a/src/sample/deferredRendering/fragmentGBuffersDebugView.wgsl
+++ b/src/sample/deferredRendering/fragmentGBuffersDebugView.wgsl
@@ -15,13 +15,13 @@ fn main([[builtin(position)]] coord : vec4<f32>)
   if (c.x < 0.33333) {
     result = textureLoad(
       gBufferPosition,
-      vec2<i32>(round(coord.xy)),
+      vec2<i32>(floor(coord.xy)),
       0
     );
   } elseif (c.x < 0.66667) {
     result = textureLoad(
       gBufferNormal,
-      vec2<i32>(round(coord.xy)),
+      vec2<i32>(floor(coord.xy)),
       0
     );
     result.x = (result.x + 1.0) * 0.5;
@@ -30,7 +30,7 @@ fn main([[builtin(position)]] coord : vec4<f32>)
   } else {
     result = textureLoad(
       gBufferAlbedo,
-      vec2<i32>(round(coord.xy)),
+      vec2<i32>(floor(coord.xy)),
       0
     );
   }


### PR DESCRIPTION
https://github.com/austinEng/webgpu-samples/issues/130

`round` has the following behavior
> When e lies halfway between integers k and k+1, the result is k when k is even, and k+1 when k is odd.

It ends in image having **half resolution**.
Change to `floor`. For `textureLoad`, it make sense for a `(0.5, 0.5)` to load the texel at `(0, 0)`

https://bugs.chromium.org/p/tint/issues/detail?id=1089