### PR TITLE
Fix mixed uses of implicit and getBindGroupLayout from default pipeline layouts

### DIFF
--- a/src/pages/samples/reversedZ.ts
+++ b/src/pages/samples/reversedZ.ts
@@ -265,8 +265,9 @@ async function init(canvas: HTMLCanvasElement, gui?: GUI) {
   );
   precisionPassRenderPipelineDescriptorBase.depthStencil.depthCompare =
     depthCompareFuncs[DepthBufferMode.Reversed];
-  precisionPassPipelines[DepthBufferMode.Reversed] =
-    device.createRenderPipeline(precisionPassRenderPipelineDescriptorBase);
+  precisionPassPipelines[
+    DepthBufferMode.Reversed
+  ] = device.createRenderPipeline(precisionPassRenderPipelineDescriptorBase);
 
   // colorPass is the regular render pass to render the scene
   const colorPassRenderPiplineLayout = device.createPipelineLayout({

--- a/src/pages/samples/shadowMapping.ts
+++ b/src/pages/samples/shadowMapping.ts
@@ -89,7 +89,22 @@ async function init(canvas: HTMLCanvasElement) {
     cullMode: 'back',
   };
 
+  const uniformBufferBindGroupLayout = device.createBindGroupLayout({
+    entries: [
+      {
+        binding: 0,
+        visibility: GPUShaderStage.VERTEX,
+        buffer: {
+          type: 'uniform',
+        },
+      },
+    ],
+  });
+
   const shadowPipeline = device.createRenderPipeline({
+    layout: device.createPipelineLayout({
+      bindGroupLayouts: [uniformBufferBindGroupLayout, uniformBufferBindGroupLayout],
+    }),
     vertex: {
       module: device.createShaderModule({
         code: wgslShaders.vertexShadow,
@@ -144,10 +159,8 @@ async function init(canvas: HTMLCanvasElement) {
   });
 
   const pipeline = device.createRenderPipeline({
-    // Specify the pipeline layout. The layout for the model is the same, so
-    // reuse it from the shadow pipeline.
     layout: device.createPipelineLayout({
-      bindGroupLayouts: [bglForRender, shadowPipeline.getBindGroupLayout(1)],
+      bindGroupLayouts: [bglForRender, uniformBufferBindGroupLayout],
     }),
     vertex: {
       module: device.createShaderModule({
@@ -215,7 +228,7 @@ async function init(canvas: HTMLCanvasElement) {
   });
 
   const sceneBindGroupForShadow = device.createBindGroup({
-    layout: shadowPipeline.getBindGroupLayout(0),
+    layout: uniformBufferBindGroupLayout,
     entries: [
       {
         binding: 0,
@@ -249,7 +262,7 @@ async function init(canvas: HTMLCanvasElement) {
   });
 
   const modelBindGroup = device.createBindGroup({
-    layout: shadowPipeline.getBindGroupLayout(1),
+    layout: uniformBufferBindGroupLayout,
     entries: [
       {
         binding: 0,

--- a/src/pages/samples/shadowMapping.ts
+++ b/src/pages/samples/shadowMapping.ts
@@ -103,7 +103,10 @@ async function init(canvas: HTMLCanvasElement) {
 
   const shadowPipeline = device.createRenderPipeline({
     layout: device.createPipelineLayout({
-      bindGroupLayouts: [uniformBufferBindGroupLayout, uniformBufferBindGroupLayout],
+      bindGroupLayouts: [
+        uniformBufferBindGroupLayout,
+        uniformBufferBindGroupLayout,
+      ],
     }),
     vertex: {
       module: device.createShaderModule({

--- a/src/sample/deferredRendering/fragmentDeferredRendering.wgsl
+++ b/src/sample/deferredRendering/fragmentDeferredRendering.wgsl
@@ -1,6 +1,6 @@
-[[group(0), binding(1)]] var gBufferPosition: texture_2d<f32>;
-[[group(0), binding(2)]] var gBufferNormal: texture_2d<f32>;
-[[group(0), binding(3)]] var gBufferAlbedo: texture_2d<f32>;
+[[group(0), binding(0)]] var gBufferPosition: texture_2d<f32>;
+[[group(0), binding(1)]] var gBufferNormal: texture_2d<f32>;
+[[group(0), binding(2)]] var gBufferAlbedo: texture_2d<f32>;
 
 struct LightData {
   position : vec4<f32>;

--- a/src/sample/deferredRendering/fragmentGBuffersDebugView.wgsl
+++ b/src/sample/deferredRendering/fragmentGBuffersDebugView.wgsl
@@ -1,6 +1,6 @@
-[[group(0), binding(1)]] var gBufferPosition: texture_2d<f32>;
-[[group(0), binding(2)]] var gBufferNormal: texture_2d<f32>;
-[[group(0), binding(3)]] var gBufferAlbedo: texture_2d<f32>;
+[[group(0), binding(0)]] var gBufferPosition: texture_2d<f32>;
+[[group(0), binding(1)]] var gBufferNormal: texture_2d<f32>;
+[[group(0), binding(2)]] var gBufferAlbedo: texture_2d<f32>;
 
 [[block]] struct CanvasConstants {
   size: vec2<f32>;

--- a/src/sample/deferredRendering/main.ts
+++ b/src/sample/deferredRendering/main.ts
@@ -145,7 +145,70 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
     primitive,
   });
 
+  const gBufferTexturesBindGroupLayout = device.createBindGroupLayout({
+    entries: [
+      {
+        binding: 0,
+        visibility: GPUShaderStage.FRAGMENT,
+        texture: {
+          sampleType: 'unfilterable-float',
+        },
+      },
+      {
+        binding: 1,
+        visibility: GPUShaderStage.FRAGMENT,
+        texture: {
+          sampleType: 'unfilterable-float',
+        },
+      },
+      {
+        binding: 2,
+        visibility: GPUShaderStage.FRAGMENT,
+        texture: {
+          sampleType: 'unfilterable-float',
+        },
+      },
+    ],
+  });
+
+  const lightsBufferBindGroupLayout = device.createBindGroupLayout({
+    entries: [
+      {
+        binding: 0,
+        visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.COMPUTE,
+        buffer: {
+          type: 'storage',
+        },
+      },
+      {
+        binding: 1,
+        visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.COMPUTE,
+        buffer: {
+          type: 'uniform',
+        },
+      },
+    ],
+  });
+
+  const canvasSizeUniformBindGroupLayout = device.createBindGroupLayout({
+    entries: [
+      {
+        binding: 0,
+        visibility: GPUShaderStage.FRAGMENT,
+        buffer: {
+          type: 'uniform',
+        },
+      },
+    ],
+  });
+
   const gBuffersDebugViewPipeline = device.createRenderPipeline({
+    layout: device.createPipelineLayout({
+      bindGroupLayouts: [
+        gBufferTexturesBindGroupLayout,
+        canvasSizeUniformBindGroupLayout,
+      ],
+    }),
     vertex: {
       module: device.createShaderModule({
         code: vertexTextureQuad,
@@ -167,6 +230,13 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
   });
 
   const deferredRenderPipeline = device.createRenderPipeline({
+    layout: device.createPipelineLayout({
+      bindGroupLayouts: [
+        gBufferTexturesBindGroupLayout,
+        lightsBufferBindGroupLayout,
+        canvasSizeUniformBindGroupLayout,
+      ],
+    }),
     vertex: {
       module: device.createShaderModule({
         code: vertexTextureQuad,
@@ -302,7 +372,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
   });
 
   const canvasSizeUniformBindGroup = device.createBindGroup({
-    layout: gBuffersDebugViewPipeline.getBindGroupLayout(1),
+    layout: canvasSizeUniformBindGroupLayout,
     entries: [
       {
         binding: 0,
@@ -314,18 +384,18 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
   });
 
   const gBufferTexturesBindGroup = device.createBindGroup({
-    layout: gBuffersDebugViewPipeline.getBindGroupLayout(0),
+    layout: gBufferTexturesBindGroupLayout,
     entries: [
       {
-        binding: 1,
+        binding: 0,
         resource: gBufferTextureViews[0],
       },
       {
-        binding: 2,
+        binding: 1,
         resource: gBufferTextureViews[1],
       },
       {
-        binding: 3,
+        binding: 2,
         resource: gBufferTextureViews[2],
       },
     ],
@@ -392,7 +462,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
     },
   });
   const lightsBufferBindGroup = device.createBindGroup({
-    layout: deferredRenderPipeline.getBindGroupLayout(1),
+    layout: lightsBufferBindGroupLayout,
     entries: [
       {
         binding: 0,


### PR DESCRIPTION
Fixes for https://github.com/austinEng/webgpu-samples/issues/142

Mostly use explicit pipeline layouts and bind group layouts to meet the new spec requirement https://github.com/gpuweb/gpuweb/pull/2057

