### PR TITLE
Replace ignore keyword

### DIFF
--- a/src/sample/particles/probabilityMap.wgsl
+++ b/src/sample/particles/probabilityMap.wgsl
@@ -21,7 +21,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 [[stage(compute), workgroup_size(64)]]
 fn import_level([[builtin(global_invocation_id)]] coord : vec3<u32>) {
-  ignore(buf_in);
+  _ = &buf_in;
   let offset = coord.x + coord.y * ubo.width;
   buf_out.weights[offset] = textureLoad(tex_in, vec2<i32>(coord.xy), 0).w;
 }


### PR DESCRIPTION
This PR fixes the DevTools warning below in https://austin-eng.com/webgpu-samples/samples/particles sample by using `_` identifier instead of `ignore()` as documented in https://github.com/gpuweb/gpuweb/issues/2115

```
1 warning(s) generated while compiling the shader:
24:3 warning: use of deprecated intrinsic
  ignore(buf_in);
  ^^^^^^
```

@austinEng @ben-clayton 