### PR TITLE
fix deferredrendering demo's buffer binding type

### DIFF
--- a/src/sample/deferredRendering/main.ts
+++ b/src/sample/deferredRendering/main.ts
@@ -177,7 +177,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
         binding: 0,
         visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.COMPUTE,
         buffer: {
-          type: 'storage',
+          type: 'read-only-storage',
         },
       },
       {


### PR DESCRIPTION
I find deferredrendering demo  is not runnable, and i fix deferredrendering demo's buffer binding type，which make is runnable.