### PR TITLE
Update the API of webgpu to the latest.

### DIFF
--- a/src/sample/animometer/main.ts
+++ b/src/sample/animometer/main.ts
@@ -280,7 +280,8 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
       colorAttachments: [
         {
           view: undefined, // Assigned later
-          loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp:'clear',
+          clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
           storeOp: 'store',
         },
       ],
@@ -312,7 +313,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
         recordRenderPass(passEncoder);
       }
 
-      passEncoder.endPass();
+      passEncoder.end();
       device.queue.submit([commandEncoder.finish()]);
     };
   }

--- a/src/sample/computeBoids/main.ts
+++ b/src/sample/computeBoids/main.ts
@@ -89,7 +89,8 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
     colorAttachments: [
       {
         view: undefined, // Assigned later
-        loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+        loadOp:'clear',
+        clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
         storeOp: 'store',
       },
     ],
@@ -214,7 +215,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
       passEncoder.setPipeline(computePipeline);
       passEncoder.setBindGroup(0, particleBindGroups[t % 2]);
       passEncoder.dispatch(Math.ceil(numParticles / 64));
-      passEncoder.endPass();
+      passEncoder.end();
     }
     {
       const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
@@ -222,7 +223,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
       passEncoder.setVertexBuffer(0, particleBuffers[(t + 1) % 2]);
       passEncoder.setVertexBuffer(1, spriteVertexBuffer);
       passEncoder.draw(3, numParticles, 0, 0);
-      passEncoder.endPass();
+      passEncoder.end();
     }
     device.queue.submit([commandEncoder.finish()]);
 

--- a/src/sample/deferredRendering/main.ts
+++ b/src/sample/deferredRendering/main.ts
@@ -177,7 +177,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
         binding: 0,
         visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.COMPUTE,
         buffer: {
-          type: 'storage',
+          type: 'read-only-storage',
         },
       },
       {
@@ -267,8 +267,8 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
     colorAttachments: [
       {
         view: gBufferTextureViews[0],
-
-        loadValue: {
+        loadOp:'clear',
+        clearValue: {
           r: Number.MAX_VALUE,
           g: Number.MAX_VALUE,
           b: Number.MAX_VALUE,
@@ -279,23 +279,26 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
       {
         view: gBufferTextureViews[1],
 
-        loadValue: { r: 0.0, g: 0.0, b: 1.0, a: 1.0 },
+        loadOp:'clear',
+        clearValue: { r: 0.0, g: 0.0, b: 1.0, a: 1.0 },
         storeOp: 'store',
       },
       {
         view: gBufferTextureViews[2],
-
-        loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+        loadOp:'clear',
+        clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
         storeOp: 'store',
       },
     ],
     depthStencilAttachment: {
       view: depthTexture.createView(),
 
-      depthLoadValue: 1.0,
-      depthStoreOp: 'store',
-      stencilLoadValue: 0,
-      stencilStoreOp: 'store',
+      depthLoadOp: 'clear',
+      depthClearValue: 1.0,
+      depthStoreOp:'store',
+      stencilLoadOp: 'clear',
+      stencilClearValue: 0,
+      stencilStoreOp:'store'
     },
   };
 
@@ -304,8 +307,8 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
       {
         // view is acquired and set in render loop.
         view: undefined,
-
-        loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+        loadOp:'clear',
+        clearValue:{ r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
         storeOp: 'store',
       },
     ],
@@ -597,7 +600,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
       gBufferPass.setVertexBuffer(0, vertexBuffer);
       gBufferPass.setIndexBuffer(indexBuffer, 'uint16');
       gBufferPass.drawIndexed(indexCount);
-      gBufferPass.endPass();
+      gBufferPass.end();
     }
     {
       // Update lights position
@@ -605,7 +608,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
       lightPass.setPipeline(lightUpdateComputePipeline);
       lightPass.setBindGroup(0, lightsBufferComputeBindGroup);
       lightPass.dispatch(Math.ceil(kMaxNumLights / 64));
-      lightPass.endPass();
+      lightPass.end();
     }
     {
       if (settings.mode === 'gBuffers view') {
@@ -623,7 +626,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
         debugViewPass.setBindGroup(0, gBufferTexturesBindGroup);
         debugViewPass.setBindGroup(1, canvasSizeUniformBindGroup);
         debugViewPass.draw(6);
-        debugViewPass.endPass();
+        debugViewPass.end();
       } else {
         // Deferred rendering
         textureQuadPassDescriptor.colorAttachments[0].view = context
@@ -637,7 +640,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
         deferredRenderingPass.setBindGroup(1, lightsBufferBindGroup);
         deferredRenderingPass.setBindGroup(2, canvasSizeUniformBindGroup);
         deferredRenderingPass.draw(6);
-        deferredRenderingPass.endPass();
+        deferredRenderingPass.end();
       }
     }
     device.queue.submit([commandEncoder.finish()]);

--- a/src/sample/fractalCube/main.ts
+++ b/src/sample/fractalCube/main.ts
@@ -150,18 +150,19 @@ const init: SampleInit = async ({ canvasRef }) => {
     colorAttachments: [
       {
         view: undefined, // Assigned later
-
-        loadValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
+        loadOp:'clear',
+        clearValue:{ r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
         storeOp: 'store',
       },
     ],
     depthStencilAttachment: {
       view: depthTexture.createView(),
-
-      depthLoadValue: 1.0,
-      depthStoreOp: 'store',
-      stencilLoadValue: 0,
-      stencilStoreOp: 'store',
+      depthLoadOp: 'clear',
+      depthClearValue: 1.0,
+      depthStoreOp:'store',
+      stencilLoadOp: 'clear',
+      stencilClearValue: 0,
+      stencilStoreOp:'store'
     },
   };
 
@@ -208,7 +209,7 @@ const init: SampleInit = async ({ canvasRef }) => {
     passEncoder.setBindGroup(0, uniformBindGroup);
     passEncoder.setVertexBuffer(0, verticesBuffer);
     passEncoder.draw(cubeVertexCount, 1, 0, 0);
-    passEncoder.endPass();
+    passEncoder.end();
 
     // Copy the rendering results from the swapchain into |cubeTexture|.
     commandEncoder.copyTextureToTexture(

--- a/src/sample/helloTriangle/main.ts
+++ b/src/sample/helloTriangle/main.ts
@@ -57,7 +57,8 @@ const init: SampleInit = async ({ canvasRef }) => {
       colorAttachments: [
         {
           view: textureView,
-          loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+          clearValue:{ r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp:'clear',
           storeOp: 'store',
         },
       ],
@@ -66,7 +67,7 @@ const init: SampleInit = async ({ canvasRef }) => {
     const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
     passEncoder.setPipeline(pipeline);
     passEncoder.draw(3, 1, 0, 0);
-    passEncoder.endPass();
+    passEncoder.end();
 
     device.queue.submit([commandEncoder.finish()]);
     requestAnimationFrame(frame);

--- a/src/sample/helloTriangleMSAA/main.ts
+++ b/src/sample/helloTriangleMSAA/main.ts
@@ -70,7 +70,8 @@ const init: SampleInit = async ({ canvasRef }) => {
         {
           view,
           resolveTarget: context.getCurrentTexture().createView(),
-          loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+          clearValue:{ r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp:'clear',
           storeOp: 'discard',
         },
       ],
@@ -79,7 +80,7 @@ const init: SampleInit = async ({ canvasRef }) => {
     const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
     passEncoder.setPipeline(pipeline);
     passEncoder.draw(3, 1, 0, 0);
-    passEncoder.endPass();
+    passEncoder.end();
 
     device.queue.submit([commandEncoder.finish()]);
     requestAnimationFrame(frame);

--- a/src/sample/imageBlur/main.ts
+++ b/src/sample/imageBlur/main.ts
@@ -270,13 +270,14 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
       );
     }
 
-    computePass.endPass();
+    computePass.end();
 
     const passEncoder = commandEncoder.beginRenderPass({
       colorAttachments: [
         {
           view: context.getCurrentTexture().createView(),
-          loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp:'clear',
+          clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
           storeOp: 'store',
         },
       ],
@@ -285,7 +286,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
     passEncoder.setPipeline(fullscreenQuadPipeline);
     passEncoder.setBindGroup(0, showResultBindGroup);
     passEncoder.draw(6, 1, 0, 0);
-    passEncoder.endPass();
+    passEncoder.end();
     device.queue.submit([commandEncoder.finish()]);
 
     requestAnimationFrame(frame);

--- a/src/sample/instancedCube/main.ts
+++ b/src/sample/instancedCube/main.ts
@@ -194,18 +194,19 @@ const init: SampleInit = async ({ canvasRef }) => {
     colorAttachments: [
       {
         view: undefined, // Assigned later
-
-        loadValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
+        loadOp:'clear',
+        clearValue:{ r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
         storeOp: 'store',
       },
     ],
     depthStencilAttachment: {
       view: depthTexture.createView(),
-
-      depthLoadValue: 1.0,
-      depthStoreOp: 'store',
-      stencilLoadValue: 0,
-      stencilStoreOp: 'store',
+      depthLoadOp: 'clear',
+      depthClearValue: 1.0,
+      depthStoreOp:'store',
+      stencilLoadOp: 'clear',
+      stencilClearValue: 0,
+      stencilStoreOp:'store'
     },
   };
 
@@ -233,7 +234,7 @@ const init: SampleInit = async ({ canvasRef }) => {
     passEncoder.setBindGroup(0, uniformBindGroup);
     passEncoder.setVertexBuffer(0, verticesBuffer);
     passEncoder.draw(cubeVertexCount, numInstances, 0, 0);
-    passEncoder.endPass();
+    passEncoder.end();
     device.queue.submit([commandEncoder.finish()]);
 
     requestAnimationFrame(frame);

--- a/src/sample/particles/main.ts
+++ b/src/sample/particles/main.ts
@@ -149,17 +149,19 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
     colorAttachments: [
       {
         view: undefined, // Assigned later
-        loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+        loadOp:'clear',
+        clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
         storeOp: 'store',
       },
     ],
     depthStencilAttachment: {
       view: depthTexture.createView(),
-
-      depthLoadValue: 1.0,
-      depthStoreOp: 'store',
-      stencilLoadValue: 0,
-      stencilStoreOp: 'store',
+      depthLoadOp: 'clear',
+      depthClearValue: 1.0,
+      depthStoreOp:'store',
+      stencilLoadOp: 'clear',
+      stencilClearValue: 0,
+      stencilStoreOp:'store'
     },
   };
 
@@ -312,13 +314,13 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
         passEncoder.setPipeline(probabilityMapImportLevelPipeline);
         passEncoder.setBindGroup(0, probabilityMapBindGroup);
         passEncoder.dispatch(Math.ceil(levelWidth / 64), levelHeight);
-        passEncoder.endPass();
+        passEncoder.end();
       } else {
         const passEncoder = commandEncoder.beginComputePass();
         passEncoder.setPipeline(probabilityMapExportLevelPipeline);
         passEncoder.setBindGroup(0, probabilityMapBindGroup);
         passEncoder.dispatch(Math.ceil(levelWidth / 64), levelHeight);
-        passEncoder.endPass();
+        passEncoder.end();
       }
     }
     device.queue.submit([commandEncoder.finish()]);
@@ -437,7 +439,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
       passEncoder.setPipeline(computePipeline);
       passEncoder.setBindGroup(0, computeBindGroup);
       passEncoder.dispatch(Math.ceil(numParticles / 64));
-      passEncoder.endPass();
+      passEncoder.end();
     }
     {
       const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
@@ -446,7 +448,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
       passEncoder.setVertexBuffer(0, particlesBuffer);
       passEncoder.setVertexBuffer(1, quadVertexBuffer);
       passEncoder.draw(6, numParticles, 0, 0);
-      passEncoder.endPass();
+      passEncoder.end();
     }
 
     device.queue.submit([commandEncoder.finish()]);

--- a/src/sample/resizeCanvas/main.ts
+++ b/src/sample/resizeCanvas/main.ts
@@ -102,7 +102,8 @@ const init: SampleInit = async ({ canvasRef }) => {
         {
           view: renderTargetView,
           resolveTarget: context.getCurrentTexture().createView(),
-          loadValue: { r: 0.2, g: 0.2, b: 0.2, a: 1.0 },
+          clearValue:{ r: 0.2, g: 0.2, b: 0.2, a: 1.0},
+          loadOp:'clear',
           storeOp: 'store',
         },
       ],
@@ -111,7 +112,7 @@ const init: SampleInit = async ({ canvasRef }) => {
     const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
     passEncoder.setPipeline(pipeline);
     passEncoder.draw(3, 1, 0, 0);
-    passEncoder.endPass();
+    passEncoder.end();
 
     device.queue.submit([commandEncoder.finish()]);
     requestAnimationFrame(frame);

--- a/src/sample/reversedZ/main.ts
+++ b/src/sample/reversedZ/main.ts
@@ -377,11 +377,12 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
     colorAttachments: [],
     depthStencilAttachment: {
       view: depthTextureView,
-
-      depthLoadValue: 1.0,
-      depthStoreOp: 'store',
-      stencilLoadValue: 0,
-      stencilStoreOp: 'store',
+      depthLoadOp: 'clear',
+      depthClearValue: 1.0,
+      depthStoreOp:'store',
+      stencilLoadOp: 'clear',
+      stencilClearValue: 0,
+      stencilStoreOp:'store'
     },
   };
 
@@ -394,18 +395,19 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
       {
         // view is acquired and set in render loop.
         view: undefined,
-
-        loadValue: { r: 0.0, g: 0.0, b: 0.5, a: 1.0 },
+        loadOp:'clear',
+        clearValue: { r: 0.0, g: 0.0, b: 0.5, a: 1.0 },
         storeOp: 'store',
       },
     ],
     depthStencilAttachment: {
       view: defaultDepthTextureView,
-
-      depthLoadValue: 1.0,
-      depthStoreOp: 'store',
-      stencilLoadValue: 0.0,
-      stencilStoreOp: 'store',
+      depthLoadOp: 'clear',
+      depthClearValue: 1.0,
+      depthStoreOp:'store',
+      stencilLoadOp: 'clear',
+      stencilClearValue: 0,
+      stencilStoreOp:'store'
     },
   };
   const drawPassLoadDescriptor: GPURenderPassDescriptor = {
@@ -414,17 +416,18 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
         // attachment is acquired and set in render loop.
         view: undefined,
 
-        loadValue: 'load',
+        loadOp: 'load',
         storeOp: 'store',
       },
     ],
     depthStencilAttachment: {
       view: defaultDepthTextureView,
-
-      depthLoadValue: 1.0,
-      depthStoreOp: 'store',
-      stencilLoadValue: 0.0,
-      stencilStoreOp: 'store',
+      depthLoadOp: 'clear',
+      depthClearValue: 1.0,
+      depthStoreOp:'store',
+      stencilLoadOp: 'clear',
+      stencilClearValue: 0,
+      stencilStoreOp:'store'
     },
   };
   const drawPassDescriptors = [drawPassDescriptor, drawPassLoadDescriptor];
@@ -434,8 +437,8 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
       {
         // view is acquired and set in render loop.
         view: undefined,
-
-        loadValue: { r: 0.0, g: 0.0, b: 0.5, a: 1.0 },
+        loadOp:'clear',
+        clearValue: { r: 0.0, g: 0.0, b: 0.5, a: 1.0 },
         storeOp: 'store',
       },
     ],
@@ -446,7 +449,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
         // view is acquired and set in render loop.
         view: undefined,
 
-        loadValue: 'load',
+        loadOp: 'load',
         storeOp: 'store',
       },
     ],
@@ -633,7 +636,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
           1
         );
         colorPass.draw(geometryDrawCount, numInstances, 0, 0);
-        colorPass.endPass();
+        colorPass.end();
       }
     } else if (settings.mode === 'precision-error') {
       for (const m of depthBufferModes) {
@@ -655,7 +658,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
             1
           );
           depthPrePass.draw(geometryDrawCount, numInstances, 0, 0);
-          depthPrePass.endPass();
+          depthPrePass.end();
         }
         {
           drawPassDescriptors[m].colorAttachments[0].view = attachment;
@@ -677,7 +680,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
             1
           );
           precisionErrorPass.draw(geometryDrawCount, numInstances, 0, 0);
-          precisionErrorPass.endPass();
+          precisionErrorPass.end();
         }
       }
     } else {
@@ -701,7 +704,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
             1
           );
           depthPrePass.draw(geometryDrawCount, numInstances, 0, 0);
-          depthPrePass.endPass();
+          depthPrePass.end();
         }
         {
           textureQuadPassDescriptors[m].colorAttachments[0].view = attachment;
@@ -719,7 +722,7 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
             1
           );
           depthTextureQuadPass.draw(6, 1, 0, 0);
-          depthTextureQuadPass.endPass();
+          depthTextureQuadPass.edn();
         }
       }
     }

--- a/src/sample/rotatingCube/main.ts
+++ b/src/sample/rotatingCube/main.ts
@@ -124,18 +124,19 @@ const init: SampleInit = async ({ canvasRef }) => {
     colorAttachments: [
       {
         view: undefined, // Assigned later
-
-        loadValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
+        loadOp:'clear',
+        clearValue:{ r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
         storeOp: 'store',
       },
     ],
     depthStencilAttachment: {
       view: depthTexture.createView(),
-
-      depthLoadValue: 1.0,
-      depthStoreOp: 'store',
-      stencilLoadValue: 0,
-      stencilStoreOp: 'store',
+      depthLoadOp: 'clear',
+      depthClearValue: 1.0,
+      depthStoreOp:'store',
+      stencilLoadOp: 'clear',
+      stencilClearValue: 0,
+      stencilStoreOp:'store'
     },
   };
 
@@ -182,7 +183,7 @@ const init: SampleInit = async ({ canvasRef }) => {
     passEncoder.setBindGroup(0, uniformBindGroup);
     passEncoder.setVertexBuffer(0, verticesBuffer);
     passEncoder.draw(cubeVertexCount, 1, 0, 0);
-    passEncoder.endPass();
+    passEncoder.end();
     device.queue.submit([commandEncoder.finish()]);
 
     requestAnimationFrame(frame);

--- a/src/sample/shadowMapping/main.ts
+++ b/src/sample/shadowMapping/main.ts
@@ -199,18 +199,19 @@ const init: SampleInit = async ({ canvasRef }) => {
       {
         // view is acquired and set in render loop.
         view: undefined,
-
-        loadValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
+        loadOp:'clear',
+        clearValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
         storeOp: 'store',
       },
     ],
     depthStencilAttachment: {
       view: depthTexture.createView(),
-
-      depthLoadValue: 1.0,
-      depthStoreOp: 'store',
-      stencilLoadValue: 0,
-      stencilStoreOp: 'store',
+      depthLoadOp: 'clear',
+      depthClearValue: 1.0,
+      depthStoreOp:'store',
+      stencilLoadOp: 'clear',
+      stencilClearValue: 0,
+      stencilStoreOp:'store'
     },
   };
 
@@ -366,10 +367,12 @@ const init: SampleInit = async ({ canvasRef }) => {
     colorAttachments: [],
     depthStencilAttachment: {
       view: shadowDepthTextureView,
-      depthLoadValue: 1.0,
-      depthStoreOp: 'store',
-      stencilLoadValue: 0,
-      stencilStoreOp: 'store',
+      depthLoadOp: 'clear',
+      depthClearValue: 1.0,
+      depthStoreOp:'store',
+      stencilLoadOp: 'clear',
+      stencilClearValue: 0,
+      stencilStoreOp:'store'
     },
   };
 
@@ -400,7 +403,7 @@ const init: SampleInit = async ({ canvasRef }) => {
       shadowPass.setIndexBuffer(indexBuffer, 'uint16');
       shadowPass.drawIndexed(indexCount);
 
-      shadowPass.endPass();
+      shadowPass.end();
     }
     {
       const renderPass = commandEncoder.beginRenderPass(renderPassDescriptor);
@@ -411,7 +414,7 @@ const init: SampleInit = async ({ canvasRef }) => {
       renderPass.setIndexBuffer(indexBuffer, 'uint16');
       renderPass.drawIndexed(indexCount);
 
-      renderPass.endPass();
+      renderPass.end();
     }
     device.queue.submit([commandEncoder.finish()]);
     requestAnimationFrame(frame);

--- a/src/sample/texturedCube/main.ts
+++ b/src/sample/texturedCube/main.ts
@@ -161,18 +161,19 @@ const init: SampleInit = async ({ canvasRef }) => {
     colorAttachments: [
       {
         view: undefined, // Assigned later
-
-        loadValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
+        loadOp:'clear',
+        clearValue:{ r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
         storeOp: 'store',
       },
     ],
     depthStencilAttachment: {
       view: depthTexture.createView(),
-
-      depthLoadValue: 1.0,
-      depthStoreOp: 'store',
-      stencilLoadValue: 0,
-      stencilStoreOp: 'store',
+      depthLoadOp: 'clear',
+      depthClearValue: 1.0,
+      depthStoreOp:'store',
+      stencilLoadOp: 'clear',
+      stencilClearValue: 0,
+      stencilStoreOp:'store'
     },
   };
 
@@ -219,7 +220,7 @@ const init: SampleInit = async ({ canvasRef }) => {
     passEncoder.setBindGroup(0, uniformBindGroup);
     passEncoder.setVertexBuffer(0, verticesBuffer);
     passEncoder.draw(cubeVertexCount, 1, 0, 0);
-    passEncoder.endPass();
+    passEncoder.end();
     device.queue.submit([commandEncoder.finish()]);
 
     requestAnimationFrame(frame);

--- a/src/sample/twoCubes/main.ts
+++ b/src/sample/twoCubes/main.ts
@@ -143,18 +143,19 @@ const init: SampleInit = async ({ canvasRef }) => {
     colorAttachments: [
       {
         view: undefined, // Assigned later
-
-        loadValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
+        loadOp:'clear',
+        clearValue:{ r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
         storeOp: 'store',
       },
     ],
     depthStencilAttachment: {
       view: depthTexture.createView(),
-
-      depthLoadValue: 1.0,
-      depthStoreOp: 'store',
-      stencilLoadValue: 0,
-      stencilStoreOp: 'store',
+      depthLoadOp: 'clear',
+      depthClearValue: 1.0,
+      depthStoreOp:'store',
+      stencilLoadOp: 'clear',
+      stencilClearValue: 0,
+      stencilStoreOp:'store'
     },
   };
 
@@ -241,7 +242,7 @@ const init: SampleInit = async ({ canvasRef }) => {
     passEncoder.setBindGroup(0, uniformBindGroup2);
     passEncoder.draw(cubeVertexCount, 1, 0, 0);
 
-    passEncoder.endPass();
+    passEncoder.end();
     device.queue.submit([commandEncoder.finish()]);
 
     requestAnimationFrame(frame);

--- a/src/sample/videoUploading/main.ts
+++ b/src/sample/videoUploading/main.ts
@@ -87,7 +87,8 @@ const init: SampleInit = async ({ canvasRef }) => {
       colorAttachments: [
         {
           view: textureView,
-          loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp:'clear',
+          clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
           storeOp: 'store',
         },
       ],
@@ -97,7 +98,7 @@ const init: SampleInit = async ({ canvasRef }) => {
     passEncoder.setPipeline(pipeline);
     passEncoder.setBindGroup(0, uniformBindGroup);
     passEncoder.draw(6, 1, 0, 0);
-    passEncoder.endPass();
+    passEncoder.end();
     device.queue.submit([commandEncoder.finish()]);
 
     requestAnimationFrame(frame);


### PR DESCRIPTION
I remove the obsolete params and update them, including color attachment's loadvalue, depth stencil attachment's depth loadvalue and stencil loadvalue.

PR details are as follows:
  1.GPURenderPassEncoder'endPass use end instead. 
  2.GPURenderPassDescriptor's colorAttachments 's loadValue use loadOp and clearValue instead.
  3.GPURenderPassDescriptor's depthStencilAttachment 's depthLoadValue use depthLoadOp and depthClearValue instead.
 4.GPURenderPassDescriptor's depthStencilAttachment 's stencilLoadValue use stencilLoadOp and stencilClearValue instead.

After that, I run every demo, and the exceptions are OK except for defer rendering.
I fixed the bug of defer rendering in this pr. #165 
