### PR TITLE
Fix createView explicit dimension 2d

### DIFF
--- a/src/sample/deferredRendering/main.ts
+++ b/src/sample/deferredRendering/main.ts
@@ -79,8 +79,16 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
     format: 'bgra8unorm',
   });
   const gBufferTextureViews = [
-    gBufferTexture2DFloat.createView({ dimension: '2d', baseArrayLayer: 0, arrayLayerCount: 1 }),
-    gBufferTexture2DFloat.createView({ dimension: '2d', baseArrayLayer: 1, arrayLayerCount: 1 }),
+    gBufferTexture2DFloat.createView({
+      dimension: '2d',
+      baseArrayLayer: 0,
+      arrayLayerCount: 1,
+    }),
+    gBufferTexture2DFloat.createView({
+      dimension: '2d',
+      baseArrayLayer: 1,
+      arrayLayerCount: 1,
+    }),
     gBufferTextureAlbedo.createView(),
   ];
 

--- a/src/sample/deferredRendering/main.ts
+++ b/src/sample/deferredRendering/main.ts
@@ -79,8 +79,8 @@ const init: SampleInit = async ({ canvasRef, gui }) => {
     format: 'bgra8unorm',
   });
   const gBufferTextureViews = [
-    gBufferTexture2DFloat.createView({ baseArrayLayer: 0, arrayLayerCount: 1 }),
-    gBufferTexture2DFloat.createView({ baseArrayLayer: 1, arrayLayerCount: 1 }),
+    gBufferTexture2DFloat.createView({ dimension: '2d', baseArrayLayer: 0, arrayLayerCount: 1 }),
+    gBufferTexture2DFloat.createView({ dimension: '2d', baseArrayLayer: 1, arrayLayerCount: 1 }),
     gBufferTextureAlbedo.createView(),
   ];
 


### PR DESCRIPTION
Fix deferredRendering sample 

> By default [createView()](https://www.w3.org/TR/webgpu/#dom-gputexture-createview) will create a view with a dimension that can represent the entire texture. For example, calling [createView()](https://www.w3.org/TR/webgpu/#dom-gputexture-createview) without specifying a [dimension](https://www.w3.org/TR/webgpu/#dom-gputextureviewdescriptor-dimension) on a ["2d"](https://www.w3.org/TR/webgpu/#dom-gputexturedimension-2d) texture with more than one layer will create a ["2d-array"](https://www.w3.org/TR/webgpu/#dom-gputextureviewdimension-2d-array) [GPUTextureView](https://www.w3.org/TR/webgpu/#gputextureview), even if an [arrayLayerCount](https://www.w3.org/TR/webgpu/#dom-gputextureviewdescriptor-arraylayercount) of 1 is specified.
