### PR TITLE
Use pipeline overridable constants

### DIFF
--- a/src/sample/deferredRendering/fragmentDeferredRendering.wgsl
+++ b/src/sample/deferredRendering/fragmentDeferredRendering.wgsl
@@ -17,11 +17,6 @@ struct Config {
 }
 @group(1) @binding(1) var<uniform> config: Config;
 
-struct CanvasConstants {
-  size: vec2<f32>,
-}
-@group(2) @binding(0) var<uniform> canvas : CanvasConstants;
-
 @fragment
 fn main(
   @builtin(position) coord : vec4<f32>

--- a/src/sample/deferredRendering/fragmentGBuffersDebugView.wgsl
+++ b/src/sample/deferredRendering/fragmentGBuffersDebugView.wgsl
@@ -2,17 +2,15 @@
 @group(0) @binding(1) var gBufferNormal: texture_2d<f32>;
 @group(0) @binding(2) var gBufferAlbedo: texture_2d<f32>;
 
-struct CanvasConstants {
-  size: vec2<f32>,
-}
-@group(1) @binding(0) var<uniform> canvas : CanvasConstants;
+override canvasSizeWidth: f32;
+override canvasSizeHeight: f32;
 
 @fragment
 fn main(
   @builtin(position) coord : vec4<f32>
 ) -> @location(0) vec4<f32> {
   var result : vec4<f32>;
-  let c = coord.xy / canvas.size;
+  let c = coord.xy / vec2<f32>(canvasSizeWidth, canvasSizeHeight);
   if (c.x < 0.33333) {
     result = textureLoad(
       gBufferPosition,

--- a/src/sample/deferredRendering/main.ts
+++ b/src/sample/deferredRendering/main.ts
@@ -235,7 +235,6 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
       bindGroupLayouts: [
         gBufferTexturesBindGroupLayout,
         lightsBufferBindGroupLayout,
-        // canvasSizeUniformBindGroupLayout,
       ],
     }),
     vertex: {

--- a/src/sample/deferredRendering/main.ts
+++ b/src/sample/deferredRendering/main.ts
@@ -202,9 +202,7 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
 
   const gBuffersDebugViewPipeline = device.createRenderPipeline({
     layout: device.createPipelineLayout({
-      bindGroupLayouts: [
-        gBufferTexturesBindGroupLayout,
-      ],
+      bindGroupLayouts: [gBufferTexturesBindGroupLayout],
     }),
     vertex: {
       module: device.createShaderModule({
@@ -223,8 +221,8 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
         },
       ],
       constants: {
-        'canvasSizeWidth': presentationSize[0],
-        'canvasSizeHeight': presentationSize[1],
+        canvasSizeWidth: presentationSize[0],
+        canvasSizeHeight: presentationSize[1],
       },
     },
     primitive,

--- a/src/sample/deferredRendering/main.ts
+++ b/src/sample/deferredRendering/main.ts
@@ -200,23 +200,10 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
     ],
   });
 
-  const canvasSizeUniformBindGroupLayout = device.createBindGroupLayout({
-    entries: [
-      {
-        binding: 0,
-        visibility: GPUShaderStage.FRAGMENT,
-        buffer: {
-          type: 'uniform',
-        },
-      },
-    ],
-  });
-
   const gBuffersDebugViewPipeline = device.createRenderPipeline({
     layout: device.createPipelineLayout({
       bindGroupLayouts: [
         gBufferTexturesBindGroupLayout,
-        canvasSizeUniformBindGroupLayout,
       ],
     }),
     vertex: {
@@ -235,6 +222,10 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
           format: presentationFormat,
         },
       ],
+      constants: {
+        'canvasSizeWidth': presentationSize[0],
+        'canvasSizeHeight': presentationSize[1],
+      },
     },
     primitive,
   });
@@ -244,7 +235,7 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
       bindGroupLayouts: [
         gBufferTexturesBindGroupLayout,
         lightsBufferBindGroupLayout,
-        canvasSizeUniformBindGroupLayout,
+        // canvasSizeUniformBindGroupLayout,
       ],
     }),
     vertex: {
@@ -374,23 +365,6 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
         binding: 1,
         resource: {
           buffer: cameraUniformBuffer,
-        },
-      },
-    ],
-  });
-
-  const canvasSizeUniformBuffer = device.createBuffer({
-    size: 4 * 2,
-    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
-  });
-
-  const canvasSizeUniformBindGroup = device.createBindGroup({
-    layout: canvasSizeUniformBindGroupLayout,
-    entries: [
-      {
-        binding: 0,
-        resource: {
-          buffer: canvasSizeUniformBuffer,
         },
       },
     ],
@@ -563,15 +537,6 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
     normalModelData.byteOffset,
     normalModelData.byteLength
   );
-  // Pass the canvas size to shader to help sample from gBuffer textures using coord
-  const canvasSizeData = new Float32Array(presentationSize);
-  device.queue.writeBuffer(
-    canvasSizeUniformBuffer,
-    0,
-    canvasSizeData.buffer,
-    canvasSizeData.byteOffset,
-    canvasSizeData.byteLength
-  );
 
   // Rotates the camera around the origin based on time.
   function getCameraViewProjMatrix() {
@@ -635,7 +600,6 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
         );
         debugViewPass.setPipeline(gBuffersDebugViewPipeline);
         debugViewPass.setBindGroup(0, gBufferTexturesBindGroup);
-        debugViewPass.setBindGroup(1, canvasSizeUniformBindGroup);
         debugViewPass.draw(6);
         debugViewPass.end();
       } else {
@@ -649,7 +613,6 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
         deferredRenderingPass.setPipeline(deferredRenderPipeline);
         deferredRenderingPass.setBindGroup(0, gBufferTexturesBindGroup);
         deferredRenderingPass.setBindGroup(1, lightsBufferBindGroup);
-        deferredRenderingPass.setBindGroup(2, canvasSizeUniformBindGroup);
         deferredRenderingPass.draw(6);
         deferredRenderingPass.end();
       }

--- a/src/sample/shadowMapping/fragment.wgsl
+++ b/src/sample/shadowMapping/fragment.wgsl
@@ -1,5 +1,4 @@
-// TODO: Use pipeline constants
-const shadowDepthTextureSize = 1024.0;
+override shadowDepthTextureSize: f32 = 1024.0;
 
 struct Scene {
   lightViewProjMatrix : mat4x4<f32>,

--- a/src/sample/shadowMapping/main.ts
+++ b/src/sample/shadowMapping/main.ts
@@ -180,6 +180,9 @@ const init: SampleInit = async ({ canvas, pageState }) => {
           format: presentationFormat,
         },
       ],
+      constants: {
+        shadowDepthTextureSize
+      }
     },
     depthStencil: {
       depthWriteEnabled: true,

--- a/src/sample/shadowMapping/main.ts
+++ b/src/sample/shadowMapping/main.ts
@@ -181,8 +181,8 @@ const init: SampleInit = async ({ canvas, pageState }) => {
         },
       ],
       constants: {
-        shadowDepthTextureSize
-      }
+        shadowDepthTextureSize,
+      },
     },
     depthStencil: {
       depthWriteEnabled: true,


### PR DESCRIPTION
Use pipeline overridable constants for `shadowMapping` and `deferredRendering`

Better to merge after Chrome M107 comes to stable (Tue, Oct 25, 2022) to avoid breaking behavior