### PR TITLE
Update origin-trial

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -50,7 +50,7 @@ const MainLayout: React.FunctionComponent<AppProps> = ({
         />
         <meta
           httpEquiv="origin-trial"
-          content="Ak1q2mlPP/liPtT5bWxAgE12zre448Gqx42aQRq4EsL8vfLPsELqk3xXKBV4iCyK9xKYc7DejNfngi6jyaW/wAwAAABOeyJvcmlnaW4iOiJodHRwczovL2F1c3Rpbi1lbmcuY29tOjQ0MyIsImZlYXR1cmUiOiJXZWJHUFUiLCJleHBpcnkiOjE2NjM3MTgzOTl9"
+          content="Al3hymV3Mt35L6R7HgcpcNoMhQxJCLbmoIKGcKx1nZnlFztXqxel/yZyzFbkLBqBeGCo3BU+ug9xW9XC33XysQ4AAABheyJvcmlnaW4iOiJodHRwczovL2F1c3Rpbi1lbmcuY29tOjQ0MyIsImZlYXR1cmUiOiJXZWJHUFUiLCJleHBpcnkiOjE2NzUyMDk1OTksImlzU3ViZG9tYWluIjp0cnVlfQ=="
         />
       </Head>
       <div className={styles.wrapper}>


### PR DESCRIPTION
The previous `origin-trial` has expired, I reapplied for one.

Currently chrome 105+ can run WebGPU.