### PR TITLE
Update WGSL

### DIFF
--- a/src/sample/animometer/animometer.wgsl
+++ b/src/sample/animometer/animometer.wgsl
@@ -23,23 +23,23 @@ fn vert_main(
   @location(0) position : vec4<f32>,
   @location(1) color : vec4<f32>
 ) -> VertexOutput {
-  var fade : f32 = (uniforms.scalarOffset + time.value * uniforms.scalar / 10.0) % 1.0;
+  var fade = (uniforms.scalarOffset + time.value * uniforms.scalar / 10.0) % 1.0;
   if (fade < 0.5) {
     fade = fade * 2.0;
   } else {
     fade = (1.0 - fade) * 2.0;
   }
-  var xpos : f32 = position.x * uniforms.scale;
-  var ypos : f32 = position.y * uniforms.scale;
-  var angle : f32 = 3.14159 * 2.0 * fade;
-  var xrot : f32 = xpos * cos(angle) - ypos * sin(angle);
-  var yrot : f32 = xpos * sin(angle) + ypos * cos(angle);
+  var xpos = position.x * uniforms.scale;
+  var ypos = position.y * uniforms.scale;
+  var angle = 3.14159 * 2.0 * fade;
+  var xrot = xpos * cos(angle) - ypos * sin(angle);
+  var yrot = xpos * sin(angle) + ypos * cos(angle);
   xpos = xrot + uniforms.offsetX;
   ypos = yrot + uniforms.offsetY;
-  
+
   var output : VertexOutput;
-  output.v_color = vec4<f32>(fade, 1.0 - fade, 0.0, 1.0) + color;
-  output.Position = vec4<f32>(xpos, ypos, 0.0, 1.0);
+  output.v_color = vec4(fade, 1.0 - fade, 0.0, 1.0) + color;
+  output.Position = vec4(xpos, ypos, 0.0, 1.0);
   return output;
 }
 

--- a/src/sample/computeBoids/sprite.wgsl
+++ b/src/sample/computeBoids/sprite.wgsl
@@ -5,14 +5,14 @@ fn vert_main(
   @location(2) a_pos : vec2<f32>
 ) -> @builtin(position) vec4<f32> {
   let angle = -atan2(a_particleVel.x, a_particleVel.y);
-  let pos = vec2<f32>(
+  let pos = vec2(
     (a_pos.x * cos(angle)) - (a_pos.y * sin(angle)),
     (a_pos.x * sin(angle)) + (a_pos.y * cos(angle))
   );
-  return vec4<f32>(pos + a_particlePos, 0.0, 1.0);
+  return vec4(pos + a_particlePos, 0.0, 1.0);
 }
 
 @fragment
 fn frag_main() -> @location(0) vec4<f32> {
-  return vec4<f32>(1.0, 1.0, 1.0, 1.0);
+  return vec4(1.0, 1.0, 1.0, 1.0);
 }

--- a/src/sample/computeBoids/updateSprites.wgsl
+++ b/src/sample/computeBoids/updateSprites.wgsl
@@ -21,19 +21,19 @@ struct Particles {
 // https://github.com/austinEng/Project6-Vulkan-Flocking/blob/master/data/shaders/computeparticles/particle.comp
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) GlobalInvocationID : vec3<u32>) {
-  var index : u32 = GlobalInvocationID.x;
+  var index = GlobalInvocationID.x;
 
   var vPos = particlesA.particles[index].pos;
   var vVel = particlesA.particles[index].vel;
-  var cMass = vec2<f32>(0.0, 0.0);
-  var cVel = vec2<f32>(0.0, 0.0);
-  var colVel = vec2<f32>(0.0, 0.0);
-  var cMassCount : u32 = 0u;
-  var cVelCount : u32 = 0u;
+  var cMass = vec2(0.0);
+  var cVel = vec2(0.0);
+  var colVel = vec2(0.0);
+  var cMassCount = 0u;
+  var cVelCount = 0u;
   var pos : vec2<f32>;
   var vel : vec2<f32>;
 
-  for (var i : u32 = 0u; i < arrayLength(&particlesA.particles); i = i + 1u) {
+  for (var i = 0u; i < arrayLength(&particlesA.particles); i++) {
     if (i == index) {
       continue;
     }
@@ -41,27 +41,24 @@ fn main(@builtin(global_invocation_id) GlobalInvocationID : vec3<u32>) {
     pos = particlesA.particles[i].pos.xy;
     vel = particlesA.particles[i].vel.xy;
     if (distance(pos, vPos) < params.rule1Distance) {
-      cMass = cMass + pos;
-      cMassCount = cMassCount + 1u;
+      cMass += pos;
+      cMassCount++;
     }
     if (distance(pos, vPos) < params.rule2Distance) {
-      colVel = colVel - (pos - vPos);
+      colVel -= pos - vPos;
     }
     if (distance(pos, vPos) < params.rule3Distance) {
-      cVel = cVel + vel;
-      cVelCount = cVelCount + 1u;
+      cVel += vel;
+      cVelCount++;
     }
   }
-  if (cMassCount > 0u) {
-    var temp = f32(cMassCount);
-    cMass = (cMass / vec2<f32>(temp, temp)) - vPos;
+  if (cMassCount > 0) {
+    cMass = (cMass / vec2(f32(cMassCount))) - vPos;
   }
-  if (cVelCount > 0u) {
-    var temp = f32(cVelCount);
-    cVel = cVel / vec2<f32>(temp, temp);
+  if (cVelCount > 0) {
+    cVel /= f32(cVelCount);
   }
-  vVel = vVel + (cMass * params.rule1Scale) + (colVel * params.rule2Scale) +
-      (cVel * params.rule3Scale);
+  vVel += (cMass * params.rule1Scale) + (colVel * params.rule2Scale) + (cVel * params.rule3Scale);
 
   // clamp velocity for a more pleasing simulation
   vVel = normalize(vVel) * clamp(length(vVel), 0.0, 0.1);

--- a/src/sample/cubemap/sampleCubemap.frag.wgsl
+++ b/src/sample/cubemap/sampleCubemap.frag.wgsl
@@ -9,6 +9,6 @@ fn main(
   // Our camera and the skybox cube are both centered at (0, 0, 0)
   // so we can use the cube geomtry position to get viewing vector to sample the cube texture.
   // The magnitude of the vector doesn't matter.
-  var cubemapVec = fragPosition.xyz - vec3<f32>(0.5, 0.5, 0.5);
+  var cubemapVec = fragPosition.xyz - vec3(0.5);
   return textureSample(myTexture, mySampler, cubemapVec);
 }

--- a/src/sample/deferredRendering/fragmentDeferredRendering.wgsl
+++ b/src/sample/deferredRendering/fragmentDeferredRendering.wgsl
@@ -26,7 +26,7 @@ struct CanvasConstants {
 fn main(
   @builtin(position) coord : vec4<f32>
 ) -> @location(0) vec4<f32> {
-  var result = vec3<f32>(0.0, 0.0, 0.0);
+  var result : vec3<f32>;
 
   let position = textureLoad(
     gBufferPosition,
@@ -50,7 +50,7 @@ fn main(
     0
   ).rgb;
 
-  for (var i : u32 = 0u; i < config.numLights; i = i + 1u) {
+  for (var i = 0u; i < config.numLights; i++) {
     let L = lightsBuffer.lights[i].position.xyz - position;
     let distance = length(L);
     if (distance > lightsBuffer.lights[i].radius) {
@@ -63,7 +63,7 @@ fn main(
   }
 
   // some manual ambient
-  result = result + vec3<f32>(0.2, 0.2, 0.2);
+  result += vec3(0.2);
 
-  return vec4<f32>(result, 1.0);
+  return vec4(result, 1.0);
 }

--- a/src/sample/deferredRendering/fragmentWriteGBuffers.wgsl
+++ b/src/sample/deferredRendering/fragmentWriteGBuffers.wgsl
@@ -17,9 +17,9 @@ fn main(
   let c = 0.2 + 0.5 * ((uv.x + uv.y) - 2.0 * floor((uv.x + uv.y) / 2.0));
 
   var output : GBufferOutput;
-  output.position = vec4<f32>(fragPosition, 1.0);
-  output.normal = vec4<f32>(fragNormal, 1.0);
-  output.albedo = vec4<f32>(c, c, c, 1.0);
+  output.position = vec4(fragPosition, 1.0);
+  output.normal = vec4(fragNormal, 1.0);
+  output.albedo = vec4(c, c, c, 1.0);
 
   return output;
 }

--- a/src/sample/deferredRendering/vertexTextureQuad.wgsl
+++ b/src/sample/deferredRendering/vertexTextureQuad.wgsl
@@ -2,9 +2,9 @@
 fn main(
   @builtin(vertex_index) VertexIndex : u32
 ) -> @builtin(position) vec4<f32> {
-  var pos = array<vec2<f32>, 6>(
-    vec2<f32>(-1.0, -1.0), vec2<f32>(1.0, -1.0), vec2<f32>(-1.0, 1.0),
-    vec2<f32>(-1.0, 1.0), vec2<f32>(1.0, -1.0), vec2<f32>(1.0, 1.0)
+  const pos = array(
+    vec2(-1.0, -1.0), vec2(1.0, -1.0), vec2(-1.0, 1.0),
+    vec2(-1.0, 1.0), vec2(1.0, -1.0), vec2(1.0, 1.0),
   );
 
   return vec4<f32>(pos[VertexIndex], 0.0, 1.0);

--- a/src/sample/deferredRendering/vertexWriteGBuffers.wgsl
+++ b/src/sample/deferredRendering/vertexWriteGBuffers.wgsl
@@ -22,9 +22,9 @@ fn main(
   @location(2) uv : vec2<f32>
 ) -> VertexOutput {
   var output : VertexOutput;
-  output.fragPosition = (uniforms.modelMatrix * vec4<f32>(position, 1.0)).xyz;
-  output.Position = camera.viewProjectionMatrix * vec4<f32>(output.fragPosition, 1.0);
-  output.fragNormal = normalize((uniforms.normalModelMatrix * vec4<f32>(normal, 1.0)).xyz);
+  output.fragPosition = (uniforms.modelMatrix * vec4(position, 1.0)).xyz;
+  output.Position = camera.viewProjectionMatrix * vec4(output.fragPosition, 1.0);
+  output.fragNormal = normalize((uniforms.normalModelMatrix * vec4(normal, 1.0)).xyz);
   output.fragUV = uv;
   return output;
 }

--- a/src/sample/fractalCube/sampleSelf.frag.wgsl
+++ b/src/sample/fractalCube/sampleSelf.frag.wgsl
@@ -6,12 +6,7 @@ fn main(
   @location(0) fragUV: vec2<f32>,
   @location(1) fragPosition: vec4<f32>
 ) -> @location(0) vec4<f32> {
-  let texColor = textureSample(myTexture, mySampler, fragUV * 0.8 + vec2<f32>(0.1, 0.1));
-  var f : f32;
-  if (length(texColor.rgb - vec3<f32>(0.5, 0.5, 0.5)) < 0.01) {
-    f = 1.0;
-  } else {
-    f = 0.0;
-  }
-  return (1.0 - f) * texColor + f * fragPosition;
+  let texColor = textureSample(myTexture, mySampler, fragUV * 0.8 + vec2(0.1));
+  let f = select(1.0, 0.0, length(texColor.rgb - vec3(0.5)) < 0.01);
+  return f * texColor + f * fragPosition;
 }

--- a/src/sample/fractalCube/sampleSelf.frag.wgsl
+++ b/src/sample/fractalCube/sampleSelf.frag.wgsl
@@ -8,5 +8,5 @@ fn main(
 ) -> @location(0) vec4<f32> {
   let texColor = textureSample(myTexture, mySampler, fragUV * 0.8 + vec2(0.1));
   let f = select(1.0, 0.0, length(texColor.rgb - vec3(0.5)) < 0.01);
-  return f * texColor + f * fragPosition;
+  return f * texColor + (1.0 - f) * fragPosition;
 }

--- a/src/sample/imageBlur/blur.wgsl
+++ b/src/sample/imageBlur/blur.wgsl
@@ -1,5 +1,5 @@
 struct Params {
-  filterDim : u32,
+  filterDim : i32,
   blockDim : u32,
 }
 
@@ -34,25 +34,23 @@ fn main(
   @builtin(workgroup_id) WorkGroupID : vec3<u32>,
   @builtin(local_invocation_id) LocalInvocationID : vec3<u32>
 ) {
-  let filterOffset : u32 = (params.filterDim - 1u) / 2u;
-  let dims : vec2<i32> = textureDimensions(inputTex, 0);
+  let filterOffset = (params.filterDim - 1) / 2;
+  let dims = vec2<i32>(textureDimensions(inputTex, 0));
+  let baseIndex = vec2<i32>(WorkGroupID.xy * vec2(params.blockDim, 4) +
+                            LocalInvocationID.xy * vec2(4, 1))
+                  - vec2(filterOffset, 0);
 
-  let baseIndex = vec2<i32>(
-    WorkGroupID.xy * vec2<u32>(params.blockDim, 4u) +
-    LocalInvocationID.xy * vec2<u32>(4u, 1u)
-  ) - vec2<i32>(i32(filterOffset), 0);
-
-  for (var r : u32 = 0u; r < 4u; r = r + 1u) {
-    for (var c : u32 = 0u; c < 4u; c = c + 1u) {
-      var loadIndex = baseIndex + vec2<i32>(i32(c), i32(r));
+  for (var r = 0; r < 4; r++) {
+    for (var c = 0; c < 4; c++) {
+      var loadIndex = baseIndex + vec2(c, r);
       if (flip.value != 0u) {
         loadIndex = loadIndex.yx;
       }
 
-      tile[r][4u * LocalInvocationID.x + c] = textureSampleLevel(
+      tile[r][4 * LocalInvocationID.x + u32(c)] = textureSampleLevel(
         inputTex,
         samp,
-        (vec2<f32>(loadIndex) + vec2<f32>(0.25, 0.25)) / vec2<f32>(dims), 
+        (vec2<f32>(loadIndex) + vec2<f32>(0.25, 0.25)) / vec2<f32>(dims),
         0.0
       ).rgb;
     }
@@ -60,23 +58,23 @@ fn main(
 
   workgroupBarrier();
 
-  for (var r : u32 = 0u; r < 4u; r = r + 1u) {
-    for (var c : u32 = 0u; c < 4u; c = c + 1u) {
-      var writeIndex = baseIndex + vec2<i32>(i32(c), i32(r));
-      if (flip.value != 0u) {
+  for (var r = 0; r < 4; r++) {
+    for (var c = 0; c < 4; c++) {
+      var writeIndex = baseIndex + vec2(c, r);
+      if (flip.value != 0) {
         writeIndex = writeIndex.yx;
       }
 
-      let center : u32 = 4u * LocalInvocationID.x + c;
+      let center = i32(4 * LocalInvocationID.x) + c;
       if (center >= filterOffset &&
-          center < 128u - filterOffset &&
+          center < 128 - filterOffset &&
           all(writeIndex < dims)) {
-        var acc : vec3<f32> = vec3<f32>(0.0, 0.0, 0.0);
-        for (var f : u32 = 0u; f < params.filterDim; f = f + 1u) {
-          var i : u32 = center + f - filterOffset;
+        var acc = vec3(0.0, 0.0, 0.0);
+        for (var f = 0; f < params.filterDim; f++) {
+          var i = center + f - filterOffset;
           acc = acc + (1.0 / f32(params.filterDim)) * tile[r][i];
         }
-        textureStore(outputTex, writeIndex, vec4<f32>(acc, 1.0));
+        textureStore(outputTex, writeIndex, vec4(acc, 1.0));
       }
     }
   }

--- a/src/sample/instancedCube/instanced.vert.wgsl
+++ b/src/sample/instancedCube/instanced.vert.wgsl
@@ -19,6 +19,6 @@ fn main(
   var output : VertexOutput;
   output.Position = uniforms.modelViewProjectionMatrix[instanceIdx] * position;
   output.fragUV = uv;
-  output.fragPosition = 0.5 * (position + vec4<f32>(1.0, 1.0, 1.0, 1.0));
+  output.fragPosition = 0.5 * (position + vec4(1.0));
   return output;
 }

--- a/src/sample/particles/particle.wgsl
+++ b/src/sample/particles/particle.wgsl
@@ -100,8 +100,8 @@ fn simulate(
   if (particle.lifetime < 0.0) {
     // Use the probability map to find where the particle should be spawned.
     // Starting with the 1x1 mip level.
-    var coord = vec2<i32>(0, 0);
-    for (var level = textureNumLevels(texture) - 1; level > 0; level = level - 1) {
+    var coord : vec2<i32>;
+    for (var level = u32(textureNumLevels(texture) - 1); level > 0; level--) {
       // Load the probability value from the mip-level
       // Generate a random number and using the probabilty values, pick the
       // next texel in the next largest mip level:

--- a/src/sample/reversedZ/vertexTextureQuad.wgsl
+++ b/src/sample/reversedZ/vertexTextureQuad.wgsl
@@ -2,10 +2,10 @@
 fn main(
   @builtin(vertex_index) VertexIndex : u32
 ) -> @builtin(position) vec4<f32> {
-  var pos : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
-    vec2<f32>(-1.0, -1.0), vec2<f32>(1.0, -1.0), vec2<f32>(-1.0, 1.0),
-    vec2<f32>(-1.0, 1.0), vec2<f32>(1.0, -1.0), vec2<f32>(1.0, 1.0)
+  const pos = array(
+    vec2(-1.0, -1.0), vec2(1.0, -1.0), vec2(-1.0, 1.0),
+    vec2(-1.0, 1.0), vec2(1.0, -1.0), vec2(1.0, 1.0),
   );
 
-  return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+  return vec4(pos[VertexIndex], 0.0, 1.0);
 }

--- a/src/sample/shadowMapping/fragment.wgsl
+++ b/src/sample/shadowMapping/fragment.wgsl
@@ -1,5 +1,5 @@
 // TODO: Use pipeline constants
-const shadowDepthTextureSize: f32 = 1024.0;
+const shadowDepthTextureSize = 1024.0;
 
 struct Scene {
   lightViewProjMatrix : mat4x4<f32>,
@@ -17,21 +17,18 @@ struct FragmentInput {
   @location(2) fragNorm : vec3<f32>,
 }
 
-const albedo : vec3<f32> = vec3<f32>(0.9, 0.9, 0.9);
-const ambientFactor : f32 = 0.2;
+const albedo = vec3<f32>(0.9);
+const ambientFactor = 0.2;
 
 @fragment
 fn main(input : FragmentInput) -> @location(0) vec4<f32> {
   // Percentage-closer filtering. Sample texels in the region
   // to smooth the result.
-  var visibility : f32 = 0.0;
+  var visibility = 0.0;
   let oneOverShadowDepthTextureSize = 1.0 / shadowDepthTextureSize;
-  for (var y : i32 = -1 ; y <= 1 ; y = y + 1) {
-    for (var x : i32 = -1 ; x <= 1 ; x = x + 1) {
-      let offset : vec2<f32> = vec2<f32>(
-        f32(x) * oneOverShadowDepthTextureSize,
-        f32(y) * oneOverShadowDepthTextureSize
-      );
+  for (var y = -1; y <= 1; y++) {
+    for (var x = -1; x <= 1; x++) {
+      let offset = vec2<f32>(vec2(x, y)) * oneOverShadowDepthTextureSize;
 
       visibility += textureSampleCompare(
         shadowMap, shadowSampler,
@@ -41,8 +38,8 @@ fn main(input : FragmentInput) -> @location(0) vec4<f32> {
   }
   visibility /= 9.0;
 
-  let lambertFactor : f32 = max(dot(normalize(scene.lightPos - input.fragPos), input.fragNorm), 0.0);
-  let lightingFactor : f32 = min(ambientFactor + visibility * lambertFactor, 1.0);
-  
-  return vec4<f32>(lightingFactor * albedo, 1.0);
+  let lambertFactor = max(dot(normalize(scene.lightPos - input.fragPos), input.fragNorm), 0.0);
+  let lightingFactor = min(ambientFactor + visibility * lambertFactor, 1.0);
+
+  return vec4(lightingFactor * albedo, 1.0);
 }

--- a/src/sample/shadowMapping/vertex.wgsl
+++ b/src/sample/shadowMapping/vertex.wgsl
@@ -27,16 +27,16 @@ fn main(
   var output : VertexOutput;
 
   // XY is in (-1, 1) space, Z is in (0, 1) space
-  let posFromLight : vec4<f32> = scene.lightViewProjMatrix * model.modelMatrix * vec4<f32>(position, 1.0);
+  let posFromLight = scene.lightViewProjMatrix * model.modelMatrix * vec4(position, 1.0);
 
   // Convert XY to (0, 1)
   // Y is flipped because texture coords are Y-down.
-  output.shadowPos = vec3<f32>(
-    posFromLight.xy * vec2<f32>(0.5, -0.5) + vec2<f32>(0.5, 0.5),
+  output.shadowPos = vec3(
+    posFromLight.xy * vec2(0.5, -0.5) + vec2(0.5),
     posFromLight.z
   );
 
-  output.Position = scene.cameraViewProjMatrix * model.modelMatrix * vec4<f32>(position, 1.0);
+  output.Position = scene.cameraViewProjMatrix * model.modelMatrix * vec4(position, 1.0);
   output.fragPos = output.Position.xyz;
   output.fragNorm = normal;
   return output;

--- a/src/sample/shadowMapping/vertexShadow.wgsl
+++ b/src/sample/shadowMapping/vertexShadow.wgsl
@@ -15,5 +15,5 @@ struct Model {
 fn main(
   @location(0) position: vec3<f32>
 ) -> @builtin(position) vec4<f32> {
-  return scene.lightViewProjMatrix * model.modelMatrix * vec4<f32>(position, 1.0);
+  return scene.lightViewProjMatrix * model.modelMatrix * vec4(position, 1.0);
 }

--- a/src/shaders/basic.vert.wgsl
+++ b/src/shaders/basic.vert.wgsl
@@ -17,6 +17,6 @@ fn main(
   var output : VertexOutput;
   output.Position = uniforms.modelViewProjectionMatrix * position;
   output.fragUV = uv;
-  output.fragPosition = 0.5 * (position + vec4<f32>(1.0, 1.0, 1.0, 1.0));
+  output.fragPosition = 0.5 * (position + vec4(1.0, 1.0, 1.0, 1.0));
   return output;
 }

--- a/src/shaders/fullscreenTexturedQuad.wgsl
+++ b/src/shaders/fullscreenTexturedQuad.wgsl
@@ -8,26 +8,26 @@ struct VertexOutput {
 
 @vertex
 fn vert_main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
-  var pos = array<vec2<f32>, 6>(
-    vec2<f32>( 1.0,  1.0),
-    vec2<f32>( 1.0, -1.0),
-    vec2<f32>(-1.0, -1.0),
-    vec2<f32>( 1.0,  1.0),
-    vec2<f32>(-1.0, -1.0),
-    vec2<f32>(-1.0,  1.0)
+  const pos = array(
+    vec2( 1.0,  1.0),
+    vec2( 1.0, -1.0),
+    vec2(-1.0, -1.0),
+    vec2( 1.0,  1.0),
+    vec2(-1.0, -1.0),
+    vec2(-1.0,  1.0),
   );
 
-  var uv = array<vec2<f32>, 6>(
-    vec2<f32>(1.0, 0.0),
-    vec2<f32>(1.0, 1.0),
-    vec2<f32>(0.0, 1.0),
-    vec2<f32>(1.0, 0.0),
-    vec2<f32>(0.0, 1.0),
-    vec2<f32>(0.0, 0.0)
+  const uv = array(
+    vec2(1.0, 0.0),
+    vec2(1.0, 1.0),
+    vec2(0.0, 1.0),
+    vec2(1.0, 0.0),
+    vec2(0.0, 1.0),
+    vec2(0.0, 0.0),
   );
 
   var output : VertexOutput;
-  output.Position = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+  output.Position = vec4(pos[VertexIndex], 0.0, 1.0);
   output.fragUV = uv[VertexIndex];
   return output;
 }

--- a/src/shaders/red.frag.wgsl
+++ b/src/shaders/red.frag.wgsl
@@ -1,4 +1,4 @@
 @fragment
 fn main() -> @location(0) vec4<f32> {
-  return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+  return vec4(1.0, 0.0, 0.0, 1.0);
 }

--- a/src/shaders/triangle.vert.wgsl
+++ b/src/shaders/triangle.vert.wgsl
@@ -3,9 +3,9 @@ fn main(
   @builtin(vertex_index) VertexIndex : u32
 ) -> @builtin(position) vec4<f32> {
   var pos = array<vec2<f32>, 3>(
-    vec2<f32>(0.0, 0.5),
-    vec2<f32>(-0.5, -0.5),
-    vec2<f32>(0.5, -0.5)
+    vec2(0.0, 0.5),
+    vec2(-0.5, -0.5),
+    vec2(0.5, -0.5)
   );
 
   return vec4<f32>(pos[VertexIndex], 0.0, 1.0);


### PR DESCRIPTION
Ensure that texture queries compile when returning signed and unsigned integers, while Chrome migrates to the unsigned forms.

Also update WGSL to use type inferencing on variables, vector constructors, and abstract-numeric implict conversions, where possible.