### PR TITLE
Fix `textureSampleLevel` for external texture

### DIFF
--- a/src/shaders/sampleExternalTexture.frag.wgsl
+++ b/src/shaders/sampleExternalTexture.frag.wgsl
@@ -3,5 +3,5 @@
 
 @fragment
 fn main(@location(0) fragUV : vec2<f32>) -> @location(0) vec4<f32> {
-  return textureSampleLevel(myTexture, mySampler, fragUV);
+  return textureSampleBaseClampToEdge(myTexture, mySampler, fragUV);
 }


### PR DESCRIPTION
This now needs to use `textureSampleBaseClampToEdge()`