### PR TITLE
Made the example list more mobile-friendly

### DIFF
--- a/public/menu.svg
+++ b/public/menu.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#000000">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/>
+</svg>

--- a/src/pages/MainLayout.module.css
+++ b/src/pages/MainLayout.module.css
@@ -55,6 +55,14 @@
     height: auto;
   }
 
+  .panel[data-expanded=false] .panelContents {
+    display: none;
+  }
+
+  .panel[data-expanded=true] .panelContents {
+    display: block;
+  }
+
   .expand {
     display: inline-block;
   }

--- a/src/pages/MainLayout.module.css
+++ b/src/pages/MainLayout.module.css
@@ -30,10 +30,33 @@
   color: #ff0000;
 }
 
+.expand {
+  display: none;
+  float: right;
+  width: 36px;
+  height: 36px;
+  margin-top: -0.25em;
+  background-image: url(../../public/menu.svg);
+  background-size: cover;
+}
+
 @media only screen and (max-width: 768px) {
   /* More padding on mobile for easier touch screen use */
   .exampleLink {
     padding: 0.5em 0;
+  }
+
+  .wrapper {
+    flex-direction: column;
+  }
+
+  .panel {
+    max-width: 100%;
+    height: auto;
+  }
+
+  .expand {
+    display: inline-block;
   }
 }
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import Head from 'next/head';
 import { AppProps } from 'next/app';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useState } from 'react';
 
 import './styles.css';
 import styles from './MainLayout.module.css';
@@ -16,6 +17,8 @@ const MainLayout: React.FunctionComponent<AppProps> = ({
 }) => {
   const router = useRouter();
   const samplesNames = Object.keys(pages);
+
+  const [listExpanded, setListExpanded] = useState<boolean>(false);
 
   const oldPathSyntaxMatch = router.asPath.match(/(\?wgsl=[01])#(\S+)/);
   if (oldPathSyntaxMatch) {
@@ -38,47 +41,50 @@ const MainLayout: React.FunctionComponent<AppProps> = ({
         />
       </Head>
       <div className={styles.wrapper}>
-        <nav className={`${styles.panel} ${styles.container}`}>
+        <nav
+          className={`${styles.panel} ${styles.container}`}
+          data-expanded={listExpanded}
+        >
           <h1>
             <Link href="/">{title}</Link>
             <div
-              className={`${styles.expand}`}
+              className={styles.expand}
               onClick={() => {
-                document.querySelector('nav').classList.toggle('expanded');
+                setListExpanded(!listExpanded);
               }}
             ></div>
           </h1>
-          <a href="https://github.com/austinEng/webgpu-samples">Github</a>
-          <hr />
-          <ul className={styles.exampleList}>
-            {samplesNames.map((slug) => {
-              const className =
-                router.pathname === `/samples/[slug]` &&
-                router.query['slug'] === slug
-                  ? styles.selected
-                  : undefined;
-              return (
-                <li
-                  key={slug}
-                  className={className}
-                  onMouseOver={() => {
-                    pages[slug].render.preload();
-                  }}
-                >
-                  <Link
-                    href={`/samples/${slug}`}
-                    onClick={() => {
-                      document
-                        .querySelector('nav')
-                        .classList.remove('expanded');
+          <div className={styles.panelContents}>
+            <a href="https://github.com/austinEng/webgpu-samples">Github</a>
+            <hr />
+            <ul className={styles.exampleList}>
+              {samplesNames.map((slug) => {
+                const className =
+                  router.pathname === `/samples/[slug]` &&
+                  router.query['slug'] === slug
+                    ? styles.selected
+                    : undefined;
+                return (
+                  <li
+                    key={slug}
+                    className={className}
+                    onMouseOver={() => {
+                      pages[slug].render.preload();
                     }}
                   >
-                    {slug}
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
+                    <Link
+                      href={`/samples/${slug}`}
+                      onClick={() => {
+                        setListExpanded(false);
+                      }}
+                    >
+                      {slug}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
         </nav>
         <Component {...pageProps} />
       </div>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -41,9 +41,12 @@ const MainLayout: React.FunctionComponent<AppProps> = ({
         <nav className={`${styles.panel} ${styles.container}`}>
           <h1>
             <Link href="/">{title}</Link>
-            <div className={`${styles.expand}`} onClick={() => {
-              document.querySelector('nav').classList.toggle('expanded');
-            }}></div>
+            <div
+              className={`${styles.expand}`}
+              onClick={() => {
+                document.querySelector('nav').classList.toggle('expanded');
+              }}
+            ></div>
           </h1>
           <a href="https://github.com/austinEng/webgpu-samples">Github</a>
           <hr />
@@ -62,9 +65,16 @@ const MainLayout: React.FunctionComponent<AppProps> = ({
                     pages[slug].render.preload();
                   }}
                 >
-                  <Link href={`/samples/${slug}`} onClick={() => {
-                    document.querySelector('nav').classList.remove('expanded');
-                  }}>{slug}</Link>
+                  <Link
+                    href={`/samples/${slug}`}
+                    onClick={() => {
+                      document
+                        .querySelector('nav')
+                        .classList.remove('expanded');
+                    }}
+                  >
+                    {slug}
+                  </Link>
                 </li>
               );
             })}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -41,6 +41,9 @@ const MainLayout: React.FunctionComponent<AppProps> = ({
         <nav className={`${styles.panel} ${styles.container}`}>
           <h1>
             <Link href="/">{title}</Link>
+            <div className={`${styles.expand}`} onClick={() => {
+              document.querySelector('nav').classList.toggle('expanded');
+            }}></div>
           </h1>
           <a href="https://github.com/austinEng/webgpu-samples">Github</a>
           <hr />
@@ -59,7 +62,9 @@ const MainLayout: React.FunctionComponent<AppProps> = ({
                     pages[slug].render.preload();
                   }}
                 >
-                  <Link href={`/samples/${slug}`}>{slug}</Link>
+                  <Link href={`/samples/${slug}`} onClick={() => {
+                    document.querySelector('nav').classList.remove('expanded');
+                  }}>{slug}</Link>
                 </li>
               );
             })}

--- a/src/pages/styles.css
+++ b/src/pages/styles.css
@@ -34,13 +34,3 @@ main {
   padding-left: 15px;
   padding-right: 15px;
 }
-
-@media only screen and (max-width: 768px) {
-  nav ul, nav>a, nav hr {
-    display: none;
-  }
-
-  nav.expanded ul, nav.expanded>a, nav.expanded hr {
-    display: block;
-  }
-}

--- a/src/pages/styles.css
+++ b/src/pages/styles.css
@@ -34,3 +34,13 @@ main {
   padding-left: 15px;
   padding-right: 15px;
 }
+
+@media only screen and (max-width: 768px) {
+  nav ul, nav>a, nav hr {
+    display: none;
+  }
+
+  nav.expanded ul, nav.expanded>a, nav.expanded hr {
+    display: block;
+  }
+}


### PR DESCRIPTION
There's currently several issues with the samples on mobile, but one of the easiest to fix is that the sidebar nav of example pages takes up most of the screen on your average mobile device. This change adjusts it so that on smaller screens the nav bar will turn into a collapsible menu at the top of the page.