### PR TITLE
Fix canvas sizing, make it mobile friendly

### DIFF
--- a/src/components/SampleLayout.module.css
+++ b/src/components/SampleLayout.module.css
@@ -4,6 +4,12 @@
   margin-top: 10px;
 }
 
+.canvasContainer>canvas {
+  width: 100%;
+  aspect-ratio: 1;
+  max-width: 600px;
+}
+
 nav.sourceFileNav ul {
   list-style-type: none;
   padding: 0;

--- a/src/components/SampleLayout.tsx
+++ b/src/components/SampleLayout.tsx
@@ -214,7 +214,7 @@ const SampleLayout: React.FunctionComponent<
           }}
           ref={guiParentRef}
         ></div>
-        <canvas ref={canvasRef} width={600} height={600}></canvas>
+        <canvas ref={canvasRef}></canvas>
       </div>
       <div>
         <nav className={styles.sourceFileNav}>

--- a/src/sample/animometer/main.ts
+++ b/src/sample/animometer/main.ts
@@ -29,15 +29,12 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
   const context = canvas.getContext('webgpu') as GPUCanvasContext;
 
   const devicePixelRatio = window.devicePixelRatio || 1;
-  const presentationSize = [
-    canvas.clientWidth * devicePixelRatio,
-    canvas.clientHeight * devicePixelRatio,
-  ];
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
   const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
   context.configure({
     device,
-    size: presentationSize,
     format: presentationFormat,
     alphaMode: 'opaque',
     usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,

--- a/src/sample/computeBoids/main.ts
+++ b/src/sample/computeBoids/main.ts
@@ -10,15 +10,12 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
   if (!pageState.active) return;
   const context = canvas.getContext('webgpu') as GPUCanvasContext;
   const devicePixelRatio = window.devicePixelRatio || 1;
-  const presentationSize = [
-    canvas.clientWidth * devicePixelRatio,
-    canvas.clientHeight * devicePixelRatio,
-  ];
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
   const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
   context.configure({
     device,
-    size: presentationSize,
     format: presentationFormat,
     alphaMode: 'opaque',
   });

--- a/src/sample/cubemap/main.ts
+++ b/src/sample/cubemap/main.ts
@@ -20,15 +20,12 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   const context = canvas.getContext('webgpu') as GPUCanvasContext;
 
   const devicePixelRatio = window.devicePixelRatio || 1;
-  const presentationSize = [
-    canvas.clientWidth * devicePixelRatio,
-    canvas.clientHeight * devicePixelRatio,
-  ];
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
   const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
   context.configure({
     device,
-    size: presentationSize,
     format: presentationFormat,
     alphaMode: 'opaque',
   });
@@ -99,7 +96,7 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   });
 
   const depthTexture = device.createTexture({
-    size: presentationSize,
+    size: [canvas.width, canvas.height],
     format: 'depth24plus',
     usage: GPUTextureUsage.RENDER_ATTACHMENT,
   });
@@ -216,7 +213,7 @@ const init: SampleInit = async ({ canvas, pageState }) => {
     },
   };
 
-  const aspect = presentationSize[0] / presentationSize[1];
+  const aspect = canvas.width / canvas.height;
   const projectionMatrix = mat4.create();
   mat4.perspective(projectionMatrix, (2 * Math.PI) / 5, aspect, 1, 3000);
 

--- a/src/sample/deferredRendering/main.ts
+++ b/src/sample/deferredRendering/main.ts
@@ -21,15 +21,12 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
   const context = canvas.getContext('webgpu') as GPUCanvasContext;
 
   const devicePixelRatio = window.devicePixelRatio || 1;
-  const presentationSize = [
-    canvas.clientWidth * devicePixelRatio,
-    canvas.clientHeight * devicePixelRatio,
-  ];
-  const aspect = presentationSize[0] / presentationSize[1];
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
+  const aspect = canvas.width / canvas.height;
   const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
   context.configure({
     device,
-    size: presentationSize,
     format: presentationFormat,
     alphaMode: 'opaque',
   });
@@ -70,12 +67,12 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
 
   // GBuffer texture render targets
   const gBufferTexture2DFloat = device.createTexture({
-    size: [...presentationSize, 2],
+    size: [canvas.width, canvas.height, 2],
     usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
     format: 'rgba32float',
   });
   const gBufferTextureAlbedo = device.createTexture({
-    size: presentationSize,
+    size: [canvas.width, canvas.height],
     usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
     format: 'bgra8unorm',
   });
@@ -221,8 +218,8 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
         },
       ],
       constants: {
-        canvasSizeWidth: presentationSize[0],
-        canvasSizeHeight: presentationSize[1],
+        canvasSizeWidth: canvas.width,
+        canvasSizeHeight: canvas.height,
       },
     },
     primitive,
@@ -256,7 +253,7 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
   });
 
   const depthTexture = device.createTexture({
-    size: presentationSize,
+    size: [canvas.width, canvas.height],
     format: 'depth24plus',
     usage: GPUTextureUsage.RENDER_ATTACHMENT,
   });

--- a/src/sample/fractalCube/main.ts
+++ b/src/sample/fractalCube/main.ts
@@ -20,15 +20,12 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   const context = canvas.getContext('webgpu') as GPUCanvasContext;
 
   const devicePixelRatio = window.devicePixelRatio || 1;
-  const presentationSize = [
-    canvas.clientWidth * devicePixelRatio,
-    canvas.clientHeight * devicePixelRatio,
-  ];
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
   const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
   context.configure({
     device,
-    size: presentationSize,
     format: presentationFormat,
 
     // Specify we want both RENDER_ATTACHMENT and COPY_SRC since we
@@ -103,7 +100,7 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   });
 
   const depthTexture = device.createTexture({
-    size: presentationSize,
+    size: [canvas.width, canvas.height],
     format: 'depth24plus',
     usage: GPUTextureUsage.RENDER_ATTACHMENT,
   });
@@ -117,7 +114,7 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   // We will copy the frame's rendering results into this texture and
   // sample it on the next frame.
   const cubeTexture = device.createTexture({
-    size: presentationSize,
+    size: [canvas.width, canvas.height],
     format: presentationFormat,
     usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
   });
@@ -167,7 +164,7 @@ const init: SampleInit = async ({ canvas, pageState }) => {
     },
   };
 
-  const aspect = presentationSize[0] / presentationSize[1];
+  const aspect = canvas.width / canvas.height;
   const projectionMatrix = mat4.create();
   mat4.perspective(projectionMatrix, (2 * Math.PI) / 5, aspect, 1, 100.0);
 
@@ -221,7 +218,7 @@ const init: SampleInit = async ({ canvas, pageState }) => {
       {
         texture: cubeTexture,
       },
-      presentationSize
+      [canvas.width, canvas.height]
     );
 
     device.queue.submit([commandEncoder.finish()]);

--- a/src/sample/helloTriangleMSAA/main.ts
+++ b/src/sample/helloTriangleMSAA/main.ts
@@ -11,15 +11,12 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   const context = canvas.getContext('webgpu') as GPUCanvasContext;
 
   const devicePixelRatio = window.devicePixelRatio || 1;
-  const presentationSize = [
-    canvas.clientWidth * devicePixelRatio,
-    canvas.clientHeight * devicePixelRatio,
-  ];
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
   const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
   context.configure({
     device,
-    size: presentationSize,
     format: presentationFormat,
     alphaMode: 'opaque',
   });
@@ -54,7 +51,7 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   });
 
   const texture = device.createTexture({
-    size: presentationSize,
+    size: [canvas.width, canvas.height],
     sampleCount,
     format: presentationFormat,
     usage: GPUTextureUsage.RENDER_ATTACHMENT,

--- a/src/sample/imageBlur/main.ts
+++ b/src/sample/imageBlur/main.ts
@@ -15,15 +15,12 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
   const context = canvas.getContext('webgpu') as GPUCanvasContext;
 
   const devicePixelRatio = window.devicePixelRatio || 1;
-  const presentationSize = [
-    canvas.clientWidth * devicePixelRatio,
-    canvas.clientHeight * devicePixelRatio,
-  ];
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
   const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
   context.configure({
     device,
-    size: presentationSize,
     format: presentationFormat,
     alphaMode: 'opaque',
   });

--- a/src/sample/instancedCube/main.ts
+++ b/src/sample/instancedCube/main.ts
@@ -20,15 +20,12 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   const context = canvas.getContext('webgpu') as GPUCanvasContext;
 
   const devicePixelRatio = window.devicePixelRatio || 1;
-  const presentationSize = [
-    canvas.clientWidth * devicePixelRatio,
-    canvas.clientHeight * devicePixelRatio,
-  ];
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
   const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
   context.configure({
     device,
-    size: presentationSize,
     format: presentationFormat,
     alphaMode: 'opaque',
   });
@@ -99,7 +96,7 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   });
 
   const depthTexture = device.createTexture({
-    size: presentationSize,
+    size: [canvas.width, canvas.height],
     format: 'depth24plus',
     usage: GPUTextureUsage.RENDER_ATTACHMENT,
   });
@@ -130,7 +127,7 @@ const init: SampleInit = async ({ canvas, pageState }) => {
     ],
   });
 
-  const aspect = presentationSize[0] / presentationSize[1];
+  const aspect = canvas.width / canvas.height;
   const projectionMatrix = mat4.create();
   mat4.perspective(projectionMatrix, (2 * Math.PI) / 5, aspect, 1, 100.0);
 

--- a/src/sample/particles/main.ts
+++ b/src/sample/particles/main.ts
@@ -23,15 +23,12 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
   const context = canvas.getContext('webgpu') as GPUCanvasContext;
 
   const devicePixelRatio = window.devicePixelRatio || 1;
-  const presentationSize = [
-    canvas.clientWidth * devicePixelRatio,
-    canvas.clientHeight * devicePixelRatio,
-  ];
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
   const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
   context.configure({
     device,
-    size: presentationSize,
     format: presentationFormat,
     alphaMode: 'opaque',
   });
@@ -118,7 +115,7 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
   });
 
   const depthTexture = device.createTexture({
-    size: presentationSize,
+    size: [canvas.width, canvas.height],
     format: 'depth24plus',
     usage: GPUTextureUsage.RENDER_ATTACHMENT,
   });
@@ -375,7 +372,7 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
     ],
   });
 
-  const aspect = presentationSize[0] / presentationSize[1];
+  const aspect = canvas.width / canvas.height;
   const projection = mat4.create();
   const view = mat4.create();
   const mvp = mat4.create();

--- a/src/sample/resizeCanvas/main.ts
+++ b/src/sample/resizeCanvas/main.ts
@@ -15,14 +15,11 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
   const devicePixelRatio = window.devicePixelRatio || 1;
-  const presentationSize = [
-    canvas.clientWidth * devicePixelRatio,
-    canvas.clientHeight * devicePixelRatio,
-  ];
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
 
   context.configure({
     device,
-    size: presentationSize,
     format: presentationFormat,
     alphaMode: 'opaque',
   });
@@ -72,8 +69,7 @@ const init: SampleInit = async ({ canvas, pageState }) => {
     // When the size changes, we need to reallocate the render target.
     // We also need to set the physical size of the canvas to match the computed CSS size.
     if (
-      (currentWidth !== presentationSize[0] ||
-        currentHeight !== presentationSize[1]) &&
+      (currentWidth !== canvas.width || currentHeight !== canvas.height) &&
       currentWidth &&
       currentHeight
     ) {
@@ -82,18 +78,14 @@ const init: SampleInit = async ({ canvas, pageState }) => {
         renderTarget.destroy();
       }
 
-      presentationSize[0] = currentWidth;
-      presentationSize[1] = currentHeight;
+      // Setting the canvas width and height will automatically resize the textures returned
+      // when calling getCurrentTexture() on the context.
+      canvas.width = currentWidth;
+      canvas.height = currentHeight;
 
-      // Reconfigure the canvas size.
-      context.configure({
-        device,
-        format: presentationFormat,
-        size: presentationSize,
-      });
-
+      // Resize the multisampled render target to match the new canvas size.
       renderTarget = device.createTexture({
-        size: presentationSize,
+        size: [canvas.width, canvas.height],
         sampleCount,
         format: presentationFormat,
         usage: GPUTextureUsage.RENDER_ATTACHMENT,

--- a/src/sample/reversedZ/main.ts
+++ b/src/sample/reversedZ/main.ts
@@ -107,15 +107,12 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
   const context = canvas.getContext('webgpu') as GPUCanvasContext;
 
   const devicePixelRatio = window.devicePixelRatio || 1;
-  const presentationSize = [
-    canvas.clientWidth * devicePixelRatio,
-    canvas.clientHeight * devicePixelRatio,
-  ];
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
   const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
   context.configure({
     device,
-    size: presentationSize,
     format: presentationFormat,
     alphaMode: 'opaque',
   });
@@ -369,14 +366,14 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
   });
 
   const depthTexture = device.createTexture({
-    size: presentationSize,
+    size: [canvas.width, canvas.height],
     format: depthBufferFormat,
     usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
   });
   const depthTextureView = depthTexture.createView();
 
   const defaultDepthTexture = device.createTexture({
-    size: presentationSize,
+    size: [canvas.width, canvas.height],
     format: depthBufferFormat,
     usage: GPUTextureUsage.RENDER_ATTACHMENT,
   });
@@ -555,7 +552,7 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
   const viewMatrix = mat4.create();
   mat4.translate(viewMatrix, viewMatrix, vec3.fromValues(0, 0, -12));
 
-  const aspect = (0.5 * presentationSize[0]) / presentationSize[1];
+  const aspect = (0.5 * canvas.width) / canvas.height;
   const projectionMatrix = mat4.create();
   perspectiveZO(projectionMatrix, (2 * Math.PI) / 5, aspect, 5, Infinity);
 
@@ -633,10 +630,10 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
         colorPass.setBindGroup(0, uniformBindGroups[m]);
         colorPass.setVertexBuffer(0, verticesBuffer);
         colorPass.setViewport(
-          (presentationSize[0] * m) / 2,
+          (canvas.width * m) / 2,
           0,
-          presentationSize[0] / 2,
-          presentationSize[1],
+          canvas.width / 2,
+          canvas.height,
           0,
           1
         );
@@ -655,10 +652,10 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
           depthPrePass.setBindGroup(0, uniformBindGroups[m]);
           depthPrePass.setVertexBuffer(0, verticesBuffer);
           depthPrePass.setViewport(
-            (presentationSize[0] * m) / 2,
+            (canvas.width * m) / 2,
             0,
-            presentationSize[0] / 2,
-            presentationSize[1],
+            canvas.width / 2,
+            canvas.height,
             0,
             1
           );
@@ -677,10 +674,10 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
           precisionErrorPass.setBindGroup(1, depthTextureBindGroup);
           precisionErrorPass.setVertexBuffer(0, verticesBuffer);
           precisionErrorPass.setViewport(
-            (presentationSize[0] * m) / 2,
+            (canvas.width * m) / 2,
             0,
-            presentationSize[0] / 2,
-            presentationSize[1],
+            canvas.width / 2,
+            canvas.height,
             0,
             1
           );
@@ -701,10 +698,10 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
           depthPrePass.setBindGroup(0, uniformBindGroups[m]);
           depthPrePass.setVertexBuffer(0, verticesBuffer);
           depthPrePass.setViewport(
-            (presentationSize[0] * m) / 2,
+            (canvas.width * m) / 2,
             0,
-            presentationSize[0] / 2,
-            presentationSize[1],
+            canvas.width / 2,
+            canvas.height,
             0,
             1
           );
@@ -719,10 +716,10 @@ const init: SampleInit = async ({ canvas, pageState, gui }) => {
           depthTextureQuadPass.setPipeline(textureQuadPassPipline);
           depthTextureQuadPass.setBindGroup(0, depthTextureBindGroup);
           depthTextureQuadPass.setViewport(
-            (presentationSize[0] * m) / 2,
+            (canvas.width * m) / 2,
             0,
-            presentationSize[0] / 2,
-            presentationSize[1],
+            canvas.width / 2,
+            canvas.height,
             0,
             1
           );

--- a/src/sample/rotatingCube/main.ts
+++ b/src/sample/rotatingCube/main.ts
@@ -20,15 +20,12 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   const context = canvas.getContext('webgpu') as GPUCanvasContext;
 
   const devicePixelRatio = window.devicePixelRatio || 1;
-  const presentationSize = [
-    canvas.clientWidth * devicePixelRatio,
-    canvas.clientHeight * devicePixelRatio,
-  ];
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
   const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
   context.configure({
     device,
-    size: presentationSize,
     format: presentationFormat,
     alphaMode: 'opaque',
   });
@@ -99,7 +96,7 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   });
 
   const depthTexture = device.createTexture({
-    size: presentationSize,
+    size: [canvas.width, canvas.height],
     format: 'depth24plus',
     usage: GPUTextureUsage.RENDER_ATTACHMENT,
   });

--- a/src/sample/shadowMapping/main.ts
+++ b/src/sample/shadowMapping/main.ts
@@ -18,15 +18,12 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   const context = canvas.getContext('webgpu') as GPUCanvasContext;
 
   const devicePixelRatio = window.devicePixelRatio || 1;
-  const presentationSize = [
-    canvas.clientWidth * devicePixelRatio,
-    canvas.clientHeight * devicePixelRatio,
-  ];
-  const aspect = presentationSize[0] / presentationSize[1];
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
+  const aspect = canvas.width / canvas.height;
   const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
   context.configure({
     device,
-    size: presentationSize,
     format: presentationFormat,
     alphaMode: 'opaque',
   });
@@ -193,7 +190,7 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   });
 
   const depthTexture = device.createTexture({
-    size: presentationSize,
+    size: [canvas.width, canvas.height],
     format: 'depth24plus-stencil8',
     usage: GPUTextureUsage.RENDER_ATTACHMENT,
   });
@@ -230,7 +227,8 @@ const init: SampleInit = async ({ canvas, pageState }) => {
     // Two 4x4 viewProj matrices,
     // one for the camera and one for the light.
     // Then a vec3 for the light position.
-    size: 2 * 4 * 16 + 3 * 4,
+    // Rounded to the nearest multiple of 16.
+    size: 2 * 4 * 16 + 4 * 4,
     usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
   });
 

--- a/src/sample/texturedCube/main.ts
+++ b/src/sample/texturedCube/main.ts
@@ -20,15 +20,12 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   const context = canvas.getContext('webgpu') as GPUCanvasContext;
 
   const devicePixelRatio = window.devicePixelRatio || 1;
-  const presentationSize = [
-    canvas.clientWidth * devicePixelRatio,
-    canvas.clientHeight * devicePixelRatio,
-  ];
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
   const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
   context.configure({
     device,
-    size: presentationSize,
     format: presentationFormat,
     alphaMode: 'opaque',
   });
@@ -99,7 +96,7 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   });
 
   const depthTexture = device.createTexture({
-    size: presentationSize,
+    size: [canvas.width, canvas.height],
     format: 'depth24plus',
     usage: GPUTextureUsage.RENDER_ATTACHMENT,
   });
@@ -181,7 +178,7 @@ const init: SampleInit = async ({ canvas, pageState }) => {
     },
   };
 
-  const aspect = presentationSize[0] / presentationSize[1];
+  const aspect = canvas.width / canvas.height;
   const projectionMatrix = mat4.create();
   mat4.perspective(projectionMatrix, (2 * Math.PI) / 5, aspect, 1, 100.0);
 

--- a/src/sample/twoCubes/main.ts
+++ b/src/sample/twoCubes/main.ts
@@ -20,15 +20,12 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   const context = canvas.getContext('webgpu') as GPUCanvasContext;
 
   const devicePixelRatio = window.devicePixelRatio || 1;
-  const presentationSize = [
-    canvas.clientWidth * devicePixelRatio,
-    canvas.clientHeight * devicePixelRatio,
-  ];
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
   const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
   context.configure({
     device,
-    size: presentationSize,
     format: presentationFormat,
     alphaMode: 'opaque',
   });
@@ -99,7 +96,7 @@ const init: SampleInit = async ({ canvas, pageState }) => {
   });
 
   const depthTexture = device.createTexture({
-    size: presentationSize,
+    size: [canvas.width, canvas.height],
     format: 'depth24plus',
     usage: GPUTextureUsage.RENDER_ATTACHMENT,
   });
@@ -160,7 +157,7 @@ const init: SampleInit = async ({ canvas, pageState }) => {
     },
   };
 
-  const aspect = presentationSize[0] / presentationSize[1];
+  const aspect = canvas.width / canvas.height;
   const projectionMatrix = mat4.create();
   mat4.perspective(projectionMatrix, (2 * Math.PI) / 5, aspect, 1, 100.0);
 

--- a/src/sample/videoUploading/main.ts
+++ b/src/sample/videoUploading/main.ts
@@ -22,15 +22,12 @@ const init: SampleInit = async ({ canvas, pageState }) => {
 
   const context = canvas.getContext('webgpu') as GPUCanvasContext;
   const devicePixelRatio = window.devicePixelRatio || 1;
-  const presentationSize = [
-    canvas.clientWidth * devicePixelRatio,
-    canvas.clientHeight * devicePixelRatio,
-  ];
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
   const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
 
   context.configure({
     device,
-    size: presentationSize,
     format: presentationFormat,
     alphaMode: 'opaque',
   });


### PR DESCRIPTION
Somewhat overlaps with #194 (sorry!)

This change makes it so that the canvas is always appropriately sized for the screen, preventing unnecessary horizontal scrolling. The CSS aspect-ratio property is used to always keep the canvas square (since several of the samples make that assumption) and constrain the width to 600px. (The canvas resize sample is a little bit of an odd one out, since the height is explicitly set to 600px, but it still works fine.)

In the WebGPU code itself the canvas was assumed to be resized by passing the desired size into `context.configure()` but that's an API shaper that's been deprecated for a while now and was recently removed entirely. This CL changes it to set `canvas.width/height` directly and use those in all other necessary places for setting other target sizes and aspect ratio calculation.